### PR TITLE
Add Insomniac-exception to the Beholder

### DIFF
--- a/Beholder.cshtml
+++ b/Beholder.cshtml
@@ -7,7 +7,7 @@
 
 <h2>Beholder</h2>
 
-<p>Once per night, the Beholder can select a player. If they select an "intel" role, they will see whatever their target saw in the morning. An exception to this is if the Beholder targets a Bloodhound, then they will only see the alignment of the Bloodhound's check (the same thing a Seer would see).</p>
+<p>Once per night, the Beholder can select a player. If they select an "intel" role, they will see whatever their target saw in the morning. The first exception to this is if the Beholder targets a Bloodhound, then they will only see the alignment of the Bloodhound's check (the same thing a Seer would see). The second exception is if the Beholder targets an Insomniac. The Beholder will not see the Insomniac's morning report.</p>
 
 <h3>Notes</h3>
 <ul>


### PR DESCRIPTION
When the Beholder targets the Insomniac, the Beholder won't see the
Insomniac's morning report, the Insomniac will see that the Beholder
visited them.