### PR TITLE
Update objectives: rephrase evil factions' victory conditions

### DIFF
--- a/Objectives.txt
+++ b/Objectives.txt
@@ -2,10 +2,10 @@ Village
 "Lynch all evil doers"
 
 Wolfpack
-"Outnumber the other factions"
+"Lynch all members of other evil factions, and reach parity with the Village."
 
 Coven
-"Outnumber the other factions"
+"Lynch all members of other evil factions, and reach parity with the Village."
 
 Vampire
-"Outnumber the other factions"
+"Lynch all members of other evil factions, and reach parity with the Village."


### PR DESCRIPTION
In my opinion, the evil factions' win condition was not phrased accurately. There is first the condition, for one of the evil factions, to have all other evil factions gone. Then they have to reach parity with the village (I believe 'reaching parity with' is a bit more clear than 'outnumering').