### PR TITLE
Viewer: Specify guide name in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ This is not a full solution, and no compilation is provided, they will be copied
 Included is a simple viewer for the guide, to give you an idea of how it'll look on the main site. It requires [Node.js](https://nodejs.org/) to run. Run `npm install` within the main folder to install the required dependencies, then  `npm run dev` to open the guide viewer in the browser on port `8080`.
 
 _Note:_ The viewer does not understand Razor syntax, though it will display the common header information for each guide page.
+
+If you wish to view a guide that exists in the folder but not the sidebar, simply change the URL to `http://localhost:8080/#guide={guidename}`, replacing `{guidename}` with the file name without the extension.

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,19 +29,26 @@
 
 <script>
 import Vue from 'vue'
+import vueUrlParameters from 'vue-url-parameters';
+
 export default {
   name: 'app',
+  mixins: [vueUrlParameters],
   data () {
     return {
       loading: {
         sidebar: false,
         guide: false
       },
+      searchParams: {
+        guide: null
+      },
       guide: null
     }
   },
   mounted () {
     this.$nextTick(function () {
+      this.searchParams = this.getFiltersFromUrl(this.searchParams, true);
       this.loadSidebar();
     });
   },
@@ -66,10 +73,10 @@ export default {
         var component = new component().$mount()
         sidebar.innerHTML = '';
         sidebar.appendChild(component.$el)
-        if(this.currentPage == null) {
+        if(this.searchParams.guide == null) {
           sidebar.querySelector('li a').click();
         } else {
-          this.loadGuide(this.currentPage);
+          this.loadGuide(this.searchParams.guide);
         }
         this.loading.sidebar = false;
       }, error => {
@@ -78,6 +85,8 @@ export default {
       });
     },
     loadGuide: function(guide) {
+      this.searchParams.guide = guide;
+      this.updateUrlHash(this.searchParams);
       this.guide = null;
       this.loading.guide = true;
       this.$http.get('/guides/' + guide + '.cshtml').then(response => {


### PR DESCRIPTION
Read/update URL to include guide name. Allows refreshing the entire page instead of using the site's refresh button and opening files not in the sidebar.