### PR TITLE
Minor wording changes in regards to re-protecting/visiting players.

### DIFF
--- a/guides/Harlot.cshtml
+++ b/guides/Harlot.cshtml
@@ -18,7 +18,7 @@
 
 <h3>Notes</h3>
 <ul>
-    <li>The Harlot cannot visit the same player two nights in a row.</li>
+    <li>The Harlot cannot visit the last player that they successfully visited.</li>
     <li>The Harlot cannot observe some (parts of) abilities that are used on (living) players. These are the Djinn-swap and the target to which a Succubus redirects another player.</li>
     <li>If the Harlot observes the person that is being killed by the Wolfpack that night, the Harlot will only see one killing wolf as visitor (along with any other people that are visiting the target). For an explanation of how the Wolfpack's kill system works, see the corresponding section in the Factions page.</li>
     <li>There are some roles that visibly self-visit when using their ability. These are: the Messiah, the Tarot Reader, and the Shapeshifter. The Protector and Shaman can visit themselves if they use their defensive ability on themselves. It is also possible for a Succubus to redirect someone to themselves, making them appear self-visiting.</li>

--- a/guides/Huntsman.cshtml
+++ b/guides/Huntsman.cshtml
@@ -18,7 +18,7 @@
 
 <h3>Notes</h3>
 <ul>
-    <li>The Huntsman cannot protect the same player two nights in a row.</li>
+    <li>The Huntsman cannot protect the last player that they successfully protected or attempted to protect.</li>
     <li>The Huntsman cannot protect themselves (but the Protector can).</li>
     <li>If the Protector and Huntsman guard the same target and the wolves attack, the Huntsman's ability triggers first. So the Huntsman and killing wolf will still die.</li>
     <li>The Huntsman cannot kill a Vampire by protecting the Vampire's target. Instead, the Vampire is scared away, and everyone survives the encounter (players may still die because of other reasons).</li>

--- a/guides/Protector.cshtml
+++ b/guides/Protector.cshtml
@@ -18,7 +18,7 @@
 
 <h3>Notes</h3>
 <ul>
-    <li>The Protector cannot protect the same player two nights in a row.</li>
+    <li>The Protector cannot protect the last player that they successfully protected or attempted to protect.</li>
     <li>The Protector can protect themselves (while the Huntsman cannot).</li>
     <li>If the Protector and Huntsman guard the same target and the wolves attack, the Huntsman's ability triggers first. So the Huntsman and killing wolf will still die.</li>
     <li>A Protector cannot protect against a Militia's, Witch Hunter's, Zealot's, or Witch's killing abilities.</li>


### PR DESCRIPTION
# Description

Attempt at updating the wording of the H2P to deal with the protector role-block situation.

- N1: Protector protects PlayerFoo
- N2: Protector attempts to protects PlayerBar, Direwolf blocks Protector
- N3: Protecter is unable to protect PlayerFoo, but can attempt to protect PlayerBar

# Checklist

- [X] The content of the guides is accurate (and confirmed with the mods)
- [X] Added any required new entries in `_Sidebar.cshtml`
- [X] Checked the HTML is valid
- [X] Checked for casing and wording of keywords such as role names, factions, etc
- [X] Checked it looks correct in the browser (using bundled viewer or some other means)
