### PR TITLE
Mention 0-count roles. Close #101

### DIFF
--- a/guides/Roles/1-Village/TarotReader.cshtml
+++ b/guides/Roles/1-Village/TarotReader.cshtml
@@ -20,8 +20,8 @@
 <ul>
     <li>The Tarot Reader is seen visiting themselves (only) on the night they use their ability.</li>
     <li>The order in which the roles are given are randomised.</li>
-    <li>Players currently in the graveyard are not counted towards the per-role count. (Roles that exist within the game with no living players will show as 0.)</li>
-    <li>If players change role (eg, due to purging or recruitment) and there are no more players in the game with that role, it will not be displayed.</li>
+    <li>Players currently in the graveyard are not counted towards the per-role count (roles that exist within the game with no living players will show as 0).</li>
+    <li>If players change role (e.g. due to purging or recruitment) and there are no more players in the game with that role, it will not be displayed.</li>
     <li>The list of roles is based on the situation in the night the ability is used. It does not take into account any players that are resurrected/killed that night. This means that the role count may deviate from the number of players alive in the village the morning you get the report.</li>
 </ul>
 


### PR DESCRIPTION
# Description
Mention that tarot-reader sees 0-count roles as per the mod-message in `BGG-001` and experience from other games.

# Checklist

- [X] The content of the guides is accurate (and confirmed with the mods)
- [X] Checked the HTML is valid
- [X] Checked for casing and wording of keywords such as role names, factions, etc
- [X] Checked it looks correct in the browser (using bundled viewer or some other means)
- [X] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
