### PR TITLE
Add VM recruit count information. Closes #100

### DIFF
--- a/guides/Roles/4-Vampires/VampireMaster.cshtml
+++ b/guides/Roles/4-Vampires/VampireMaster.cshtml
@@ -18,6 +18,17 @@
      <li>The Vampire Master is seen visiting by the Harlot, Stalker, and the Familiar (Stalker).</li>
  </ul>
 
+<h3>Recruits</h3>
+
+<p>The number of recruits that can be made by a Vampire Master is not fixed, and depends on the number of total players in the game.</p>
+
+<ul>
+    <li>0-8 players: 0 recruits</li>
+    <li>9-12 players: 1 recruit</li>
+    <li>13-16 players: 2 recruits</li>
+    <li>17+ players: 3 recruits</li>
+</ul>
+
 <h3>Notes</h3>
 
 <ul>


### PR DESCRIPTION
# Description
Add VM recruit count information.

I've based this on the formula Storm mentioned a while back at the end of `ext-174`.

Technically, 1 player probably gives -1 recruits, but that seems like an unimportant detail given that it will never happen except if I need to kill off a spud game by starting it empty. :D

# Checklist

- [X] The content of the guides is accurate (and confirmed with the mods)
- [X] Checked the HTML is valid
- [X] Checked for casing and wording of keywords such as role names, factions, etc
- [X] Checked it looks correct in the browser (using bundled viewer or some other means)
- [X] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
