### PR TITLE
Add Bloodmoon Cult roles.

### DIFF
--- a/guides/Roles/7-BloodmoonCult.cshtml
+++ b/guides/Roles/7-BloodmoonCult.cshtml
@@ -1,0 +1,12 @@
+@model dynamic
+
+@{
+    ViewBag.Title = "Bloodmoon Cult Roles | werewolv.es";
+    Layout = "~/Areas/Guides/Views/Shared/_Layout.cshtml";
+}
+
+<h2>Bloodmoon Cult</h2>
+
+<p>The Bloodmoon Cult are a group of villagers who are have become disillusioned with the village and wish to see the Wolfpack destroy the village.</p>
+<p>During the course of the game, the Bloodmoon Cult are aiming to identify the Wolfpack and assist them in killing and lynching the rest of the village.</p>
+<p>The Bloodmoon Cult count towards the village for the sake of parity checks against other factions, but win when the Wolfpack wins. This means that if there are more Cult members alive than Wolfpack then someone will have to be sacrificed for the greater good to allow the Wolfpack to gain parity.</p>

--- a/guides/Roles/7-BloodmoonCult/BloodPriest.cshtml
+++ b/guides/Roles/7-BloodmoonCult/BloodPriest.cshtml
@@ -1,0 +1,33 @@
+@model dynamic
+
+@{
+    ViewBag.Title = "BloodPriest (Bloodmoon Cult) | werewolv.es";
+    Layout = "~/Areas/Guides/Views/Shared/_Layout.cshtml";
+}
+
+<h2>BloodPriest</h2>
+
+<p>The BloodPriest is a member of the Bloodmoon Cult with the ability to mark players with the Rite of Fenrir. If a player marked with this is killed the same night, they will be converted into a Werewolf.</p>
+
+<h3>Role Type</h3>
+<ul>
+	<li>The BloodPriest is afflicted with Lycanthropy.</li>
+    <li>The BloodPriest is seen as member of the Wolfpack by the Seer.</li>
+    <li>The BloodPriest is seen as a user of witchcraft.</li>
+    <li>The BloodPriest is seen visiting by the Harlot/Stalker/Familiar.</li>
+ </ul>
+
+<h3>Notes</h3>
+<ul>
+    <li>Only players afflicted with Lycanthropy can be marked.</li>
+    <li>The BloodPriest can help the wolves convert village members into Wolfpack to bolster their ranks.</li>
+    <li>The player marked by the Rite of Fenrir must be killed the same night that they are marked.</li>
+</ul>
+
+<h3>Tips for playing BloodPriest</h3>
+<ul>
+    <li>If the BloodPriest manages to get another cult member converted, then they can then help with picking future targets and wolf kills, so it may be worth coming up with a plan for this eventuality and how you would go about signalling between the factions.</li>
+</ul>
+
+<h3>History</h3>
+<p>2019-01-01: BloodPriest introduced in ext-300</p>

--- a/guides/Roles/7-BloodmoonCult/BloodSeer.cshtml
+++ b/guides/Roles/7-BloodmoonCult/BloodSeer.cshtml
@@ -1,0 +1,34 @@
+@model dynamic
+
+@{
+    ViewBag.Title = "BloodSeer (Bloodmoon Cult) | werewolv.es";
+    Layout = "~/Areas/Guides/Views/Shared/_Layout.cshtml";
+}
+
+<h3>BloodSeer</h3>
+
+<p>The BloodSeer can sense wolf blood. Once per night they can check a player and will learn if that player has wolfblood or not. Members of the Wolfpack, Players afflicted with Lycanthropy and Players marked by the Bloodletter all have wolf blood.</p>
+
+<h3>Role Type</h3>
+<ul>
+    <li>The BloodSeer is afflicted with Lycanthropy.</li>
+    <li>The BloodSeer is seen as member of the Wolfpack by a Seer.</li>
+    <li>The BloodSeer is not seen as user of witchcraft</li>
+    <li>The BloodSeer is seen visiting by the Harlot/Stalker/Familiar.</li>
+</ul>
+
+<h3>Notes</h3>
+<ul>
+    <li>The BloodSeer's checks will either be that the player has werewolf blood or does not have werewolf blood.</li>
+    <li>The BloodSeer's report is mistaken if their target is marked by the Bloodletter.</li>
+    <li>The BloodSeer can not tell the difference between an actual Werewolf, or someone afflicted with Lycanthropy.</li>
+</ul>
+
+<h3>Tips for playing BloodSeer</h3>
+<ul>
+    <li>In a game with only Wolfpack and Village, the BloodSeer can be an effective fake-seer.</li>
+    <li>The BloodSeer can hint themselves to the Wolfpack by clearing one of their members if they know who they are.</li>
+</ul>
+
+<h3>History</h3>
+<p>2019-01-01: BloodSeer introduced in ext-300</p>

--- a/guides/Roles/7-BloodmoonCult/CultLeader.cshtml
+++ b/guides/Roles/7-BloodmoonCult/CultLeader.cshtml
@@ -1,0 +1,32 @@
+@model dynamic
+
+@{
+    ViewBag.Title = "Cult Leader (Bloodmoon Cult) | werewolv.es";
+    Layout = "~/Areas/Guides/Views/Shared/_Layout.cshtml";
+}
+
+<h2>Cult Leader</h2>
+
+<p>The Cult Leader is the leader of the Bloodmoon Cult with the ability to recruit players into the Cult. Once part of the Cult, they can talk to each other in secret at night.</p>
+
+<h3>Role Type</h3>
+<ul>
+	<li>The Cult Leader is afflicted with Lycanthropy.</li>
+    <li>The Cult Leader is seen as member of the Wolfpack by the Seer.</li>
+    <li>The Cult Leader is not seen as a user of witchcraft.</li>
+    <li>The Cult Leader is seen visiting by the Harlot/Stalker/Familiar.</li>
+ </ul>
+
+<h3>Notes</h3>
+<ul>
+    <li>The Cult Leader is limited to 2 recruits per game.</li>
+    <li>The Cult Leader can only recruit players afflicted by Lycanthropy.</li>
+    <li>The Cult Leader will be killed if they try to recruit a non-villager with a killing power (including all Werewolves).</li>
+    <li>The Cult Leader has the same recruitment restrictions as other recruiters, and they are not able to recruit any player who already have a night-faction (Familiar, Coven member, Undead member, Masons, Illuminati, Inquisition Member), but will not be killed if they try. This failed recruit does not count towards the ability use limit.</li>
+    <li>The recruited villager retains their original ability.</li>
+    <li>The recruited villager is notified that they have been recruited in the morning and who recruited them, but not who any other Cult members may be.</li>
+    <li>The Cult Leader gets a notification if a successful recruit has been made. No notification is given if the recruit is unsuccessful, but in that case the Cult Leader can draw their own conclusion...</li>
+</ul>
+
+<h3>History</h3>
+<p>2019-01-01: CultLeader introduced in ext-300</p>


### PR DESCRIPTION
# Description

This adds the Bloodmoon Cult to the how to play.

I've added all 3 roles, some bits of guess work eg the Cult Leader recruitment bits.

# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [X] Checked the HTML is valid
- [X] Checked for casing and wording of keywords such as role names, factions, etc
- [X] Checked it looks correct in the browser (using bundled viewer or some other means)
- [X] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
