### PR TITLE
Test role description overview

### DIFF
--- a/guides/Roles/1-Village/Adjudicator.cshtml
+++ b/guides/Roles/1-Village/Adjudicator.cshtml
@@ -11,10 +11,13 @@
 
 <h3>Role Type</h3>
 <ul>
-     <li>The Adjudicator is seen as member of the village by the Seer.</li>
-     <li>The Adjudicator is not seen as a user of witchcraft.</li>
-     <li>The Adjudicator is seen visiting by the Harlot/Stalker/Familiar.</li>
-     <li>The Adjudicator is not seen as a killer by another Adjudicator.</li>
+  <li>Alignment: Village</li>
+  <li>Viewed Alignment: Village</li>
+  <li>Seen visiting: Yes</li>
+  <li>User of witchcraft: No</li>
+  <li>Killer: No</li>
+  <li>Kill type: N.A.</li>
+  <li>Night immunity: No</li> 
  </ul>
 
 <h3>Notes</h3>


### PR DESCRIPTION
Putting more role info into the Role Type overview instead of in Notes. This is to be implemented across all roles, this is a trial one.

# Description



# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
