### PR TITLE
Reflect clarifications from StackExchange, "What happens if two wolf …

### DIFF
--- a/guides/Roles/1-Village/Huntsman.cshtml
+++ b/guides/Roles/1-Village/Huntsman.cshtml
@@ -25,7 +25,7 @@
     <li>If the Huntsman guards a player attacked by night immune killer, such as a Vampire, the Huntsman will die in the target's place.</li>
     <li>A Huntsman cannot protect against a Militia's, Witch Hunter's, Zealot's, Witch's, or Necromancer's killing abilities.</li>
     <li>If a Huntsman is recruited by a Vampire (Master) the same night they guard somebody against a wolf's attack, that wolf dies but the Huntsman survives, becoming a Familiar as usual.</li>
-    <li>If two wolves try to attack a target guarded by the Huntsman (e.g. the wolves have a Bloodthirster), both wolves die. Any other attackers from other factions that are vulnerable to the Huntsman's defence (viz., Warlocks, Ghouls and Voodoo Doctors) also are killed. The Huntsman also protects against an additional Vampire attack, but the Vampire is not killed by the confrontation.</li>
+    <li>If two wolves try to attack a target guarded by the Huntsman (e.g. the wolves have a Bloodthirster), both wolves die, along with any other Huntsman-vulnerable attackers from other factions. The Huntsman also protects against an additional Vampire attack, but the Vampire is not killed by the confrontation.</li>
 </ul>
 
 <h3>Tips for playing Huntsman</h3>


### PR DESCRIPTION
…kills are targeted to a huntsman's target?"

See https://gaming.stackexchange.com/questions/351599/what-happens-if-two-wolf-kills-are-targeted-to-a-huntsmans-target

# Description
Kirschstein wrote,

> Both wolves would die in this scenario. Any other attackers from other factions that are vulnerable to the Huntsman's defence would also be killed. Vulnerable attackers include Warlocks, Ghouls and Voodoo Doctors. The Huntsman also would protect against an additional Vampire attack, but the Vampire would not be killed by the confrontation.
> 
> This is because when the morning starts attacks are resolved "simultaneously" - as the game acquires more interactions this may not be desirable anymore, but it certainly isn't changing in the short term.

# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
