### PR TITLE
Clarify that Diseased DOES affect bloodthirster kills

### DIFF
--- a/guides/Roles/1-Village/Diseased.cshtml
+++ b/guides/Roles/1-Village/Diseased.cshtml
@@ -8,7 +8,7 @@
 <h2>Diseased</h2>
 
 <p>The Diseased is a normal villager, but not a very nice tasting one. If the Wolfpack target the Diseased as their kill, they will suffer food posioning and not be able to kill the following night.</p>
-<p>The Diseased does not affect an Omegawolf kill, an Alphawolf kill or any non-wolfpack kills. The Diseased does affect a Bloodthirster kill.</p>
+<p>The Diseased does not affect an Omegawolf kill, an Alphawolf kill or any non-wolfpack kills. The Diseased does affect the extra kill that may be granted by a  Bloodthirster.</p>
 
 <h3>Role Type</h3>
 <ul>


### PR DESCRIPTION
# Description
The recent merge caused https://werewolv.es/guides/roles/Diseased to incorrectly say that bloodthirster kills are not affected by the Diseased; this fixes that.

See https://github.com/Kirschstein/werewolves-how-to-play/pull/151#pullrequestreview-273139028


# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
