### PR TITLE
Clarify what happens when an Omegawolf attacks a player guarded by a …

### DIFF
--- a/guides/Roles/2-Wolfpack/Omegawolf.cshtml
+++ b/guides/Roles/2-Wolfpack/Omegawolf.cshtml
@@ -23,7 +23,7 @@
 	<li>In addition to being able to visit other players and kill, the Omegawolf can also choose to guard themselves, in which case they will kill anyone who visits them.</li>
 	<li>The Omegawolf is only seen visiting their target, not the other visitors.</li>
 	<li>The Omegawolf cannot be killed at night, role-blocked, or redirected by the Succubus.</li>
-	<li>The Omegawolf can kill a protector or huntsman who is visiting another player, but the player being visited will survive, except in the case of the self-visiting protector.</li>
+	<li>The Omegawolf can kill a protector (except for a self-visiting protector) and/or huntsman who are visiting the Omegawolf's target, but the player being visited will survive.</li>
 </ul>
 
 <h3>Tips for playing Omegawolf</h3>


### PR DESCRIPTION
…huntsman. Closes #148.

See https://gaming.stackexchange.com/questions/355927/when-the-omegawolf-attacks-a-target-that-is-guarded-by-the-huntsman-which-of-th/355928#355928

# Description
Q. When the Omegawolf attacks a target that is guarded by the Huntsman, which of the three (Omegawolf, target, Huntsman) die? The Omegawolf usually can't be killed at night; does that apply to this situation, and what happens to the target and the Huntsman?
A. That is correct.  The Omegawolf won't be killed in this situation as they are immune to the kill.

The Huntsman will still sacrifice themselves though, and the target will remain alive - so in this situation only the Huntsman will die.

h/t Shane

# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
