### PR TITLE
clarify that the shapeshifter still appears to the seer as wolf-align…

### DIFF
--- a/guides/Roles/2-Wolfpack/Shapeshifter.cshtml
+++ b/guides/Roles/2-Wolfpack/Shapeshifter.cshtml
@@ -11,7 +11,7 @@
 
 <h3>Role Type</h3>
 <ul>
-    <li>The Shapeshifter is seen as a member of the Wolfpack by the Seer.</li>
+    <li>The Shapeshifter, both before and after he shifts, is seen as a member of the Wolfpack by the Seer.</li>
     <li>The Shapeshifter is seen as a user of witchcraft.</li>
     <li>The Shapeshifter is seen visiting by the Harlot/Stalker/Familiar when they are the killing wolf.</li>
     <li>The Shapeshifter's secondary ability - activating the identity swap of their shift is classed as a self visit.</li>


### PR DESCRIPTION
…ed after the shift

# Description
leucosticte Sat 11:06
really, after they shift, they still appear wolf-aligned to the seer?
Archie9608 Sat 11:07
Yes, precisely.

# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
