### PR TITLE
Clarify what the report will be when a villager who has been shifted …

### DIFF
--- a/guides/Roles/1-Village/Gravedigger.cshtml
+++ b/guides/Roles/1-Village/Gravedigger.cshtml
@@ -20,6 +20,7 @@
 <h3>Notes</h3>
 <ul>
     <li>If the Gravedigger checks the corpse of a Shapeshifter who successfully shifted away, their report will come up as "Undetermined".</li>
+    <li>After the Shapeshifter shifts into a villager, and then subsequently dies, if the Gravedigger checks that corpse, their report will be that he is a member of the wolfpack.</li>
 </ul>
 
 <h3>Tips for playing Gravedigger</h3>


### PR DESCRIPTION
…into then dies

2019-Aug-28 08:37:12 		Uta 	so let's say A is the shapeshifter, and they kill and shift into B, and then B gets lynched. What does the GD find when they dig up A, and what do they find when they dig up B?
2019-Aug-28 08:38:35 		CherylTunt 	A would be undetermined and B a werewolf?
2019-Aug-28 08:42:46 		Mannfred 	Cheryl is correct

# Description



# Checklist

- [ ] The content of the guides is accurate (and confirmed with the mods)
- [ ] Checked the HTML is valid
- [ ] Checked for casing and wording of keywords such as role names, factions, etc
- [ ] Checked it looks correct in the browser (using bundled viewer or some other means)
- [ ] Checked the sidebar links are correct and in the right order (bundled viewer will show this)
