### PR TITLE
Update deploy-beta to allow optional deploy steps.

### DIFF
--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,0 +1,3 @@
+FROM nginx:mainline-alpine AS nginx
+COPY ./public/ /usr/share/nginx/html
+EXPOSE 80

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and Deploy Beta
+    name: Build and Deploy
 
     steps:
       - name: Checkout
@@ -21,5 +21,50 @@ jobs:
       - name: Install Packages
         run: npm ci
 
-      - name: Build and Deploy
-        run: npm run deploy:beta -- --token ${{ secrets.SURGE_TOKEN }}
+      - name: Check for Deployment Target
+        id: check_vars
+        shell: bash
+        run: |
+          unset HAS_SURGE_TOKEN
+          if [ ! -z $SURGE_TOKEN ]; then HAS_SURGE_TOKEN='true' ; fi
+          echo ::set-output name=HAS_SURGE_TOKEN::${HAS_SURGE_TOKEN}
+
+          unset HAS_REGISTRY_DATA
+          if [ ! -z $DOCKER_REGISTRY -a ! -z $DOCKER_USERNAME -a ! -z $DOCKER_PASSWORD ]; then HAS_REGISTRY_DATA='true' ; fi
+          echo ::set-output name=HAS_REGISTRY_DATA::${HAS_REGISTRY_DATA}
+
+          unset HAS_UPDATE_URL
+          if [ ! -z $UPDATE_URL ]; then HAS_UPDATE_URL='true' ; fi
+          echo ::set-output name=HAS_UPDATE_URL::${HAS_UPDATE_URL}
+        env:
+          SURGE_TOKEN: "${{ secrets.SURGE_TOKEN }}"
+          DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
+          DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          UPDATE_URL: "${{ secrets.UPDATE_URL }}"
+
+      - name: Build
+        if: steps.check_vars.outputs.HAS_SURGE_TOKEN || steps.check_vars.outputs.HAS_REGISTRY_DATA
+        run: npm run build
+
+      - name: Deploy to Surge
+        if: steps.check_vars.outputs.HAS_SURGE_TOKEN
+        run: npm run deploy:beta:surge -- --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Build and Deploy to Docker Registry
+        uses: mr-smithers-excellent/docker-build-push@v2
+        if: steps.check_vars.outputs.HAS_REGISTRY_DATA
+        with:
+          image: wwes/h2p
+          tag: latest
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          dockerfile: .github/workflows/Dockerfile.deploy
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Call update webhook
+        if: steps.check_vars.outputs.HAS_UPDATE_URL
+        uses: joelwmale/webhook-action@master
+        env:
+          WEBHOOK_URL: ${{ secrets.UPDATE_URL }}
+          data: "{'commit': '${{ github.sha }}'}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,6 @@ jobs:
           UPDATE_URL: "${{ secrets.UPDATE_URL }}"
 
       - name: Build
-        if: steps.check_vars.outputs.HAS_REGISTRY_DATA
         run: npm run build
 
       - name: Build and Deploy to Docker Registry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,6 @@ jobs:
         id: check_vars
         shell: bash
         run: |
-          unset HAS_SURGE_TOKEN
-          if [ ! -z $SURGE_TOKEN ]; then HAS_SURGE_TOKEN='true' ; fi
-          echo ::set-output name=HAS_SURGE_TOKEN::${HAS_SURGE_TOKEN}
-
           unset HAS_REGISTRY_DATA
           if [ ! -z $DOCKER_REGISTRY -a ! -z $DOCKER_USERNAME -a ! -z $DOCKER_PASSWORD ]; then HAS_REGISTRY_DATA='true' ; fi
           echo ::set-output name=HAS_REGISTRY_DATA::${HAS_REGISTRY_DATA}
@@ -37,19 +33,14 @@ jobs:
           if [ ! -z $UPDATE_URL ]; then HAS_UPDATE_URL='true' ; fi
           echo ::set-output name=HAS_UPDATE_URL::${HAS_UPDATE_URL}
         env:
-          SURGE_TOKEN: "${{ secrets.SURGE_TOKEN }}"
           DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY }}"
           DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
           UPDATE_URL: "${{ secrets.UPDATE_URL }}"
 
       - name: Build
-        if: steps.check_vars.outputs.HAS_SURGE_TOKEN || steps.check_vars.outputs.HAS_REGISTRY_DATA
+        if: steps.check_vars.outputs.HAS_REGISTRY_DATA
         run: npm run build
-
-      - name: Deploy to Surge
-        if: steps.check_vars.outputs.HAS_SURGE_TOKEN
-        run: npm run deploy:beta:surge -- --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Build and Deploy to Docker Registry
         uses: mr-smithers-excellent/docker-build-push@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Beta
+name: Deploy Live
 
 on:
   push:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "serve": "gatsby serve",
     "preview": "npm run build && npm run serve",
     "pretty": "pretty-quick --pattern '**/*.{js,mdx}'",
-    "deploy:beta": "npm run build && surge public --domain https://h2p-beta.surge.sh"
+    "deploy:beta:surge": "surge public --domain https://h2p-beta.surge.sh",
+    "deploy:beta": "npm run build && npm run deploy:beta:surge"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.27",


### PR DESCRIPTION
This makes some changes to the deploy-beta workflow:

- Only try to deploy to surge if there is a `SURGE_TOKEN` secret
- If we have `DOCKER_REGISTRY`/`DOCKER_USERNAME`/`DOCKER_PASSWORD` secrets then build and push a docker image
- If we have an `UPDATE_URL` secret then poke a webhook for this commit

I split out the actual pushing to surge into `deploy:beta:surge` (but kept `deploy:beta` doing build && deploy to surge) so that the build step always happens, even if pushing to surge, or a docker registry does not. This way a build failure will still be noticed, and the webhook won't be called.

There is a weird-looking check_vars step that basically looks to see if the secrets exist and sets it's own output variables based on that because you seemingly can't just use `if: secrets.SOME_SECRET` in an action step, but can check variables output from previous steps. Go figure.

These check_vars steps could be split out to separate steps but that seemed unrequired and just duplicated things for no gain.