### PR TITLE
Change page urls

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -25,5 +25,6 @@ export default {
     { name: 'The Bloodmoon Cult', menu: ['Bloodmoon Cult'] }
   ],
   public: '/static',
-  title: 'werewolv.es'
+  title: 'werewolv.es',
+  editBranch: 'site'
 };

--- a/src/guides/bloodmoon-cult/bloodmoon-cult.mdx
+++ b/src/guides/bloodmoon-cult/bloodmoon-cult.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodmoon Cult
 menu: The Bloodmoon Cult
-route: /bloodmoon-cult
+route: /roles/BloodmoonCult
 ---
 
 # Bloodmoon Cult

--- a/src/guides/bloodmoon-cult/bloodpriest.mdx
+++ b/src/guides/bloodmoon-cult/bloodpriest.mdx
@@ -1,7 +1,7 @@
 ---
 name: Blood Priest
 menu: The Bloodmoon Cult
-route: /bloodpriest
+route: /roles/BloodPriest
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/bloodmoon-cult/bloodseer.mdx
+++ b/src/guides/bloodmoon-cult/bloodseer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Blood Seer
 menu: The Bloodmoon Cult
-route: /bloodseer
+route: /roles/BloodSeer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/bloodmoon-cult/cultfollower.mdx
+++ b/src/guides/bloodmoon-cult/cultfollower.mdx
@@ -1,7 +1,7 @@
 ---
 name: Cult Follower
 menu: The Bloodmoon Cult
-route: /cultfollower
+route: /roles/CultFollower
 ---
 
 # Cult Follower

--- a/src/guides/bloodmoon-cult/cultleader.mdx
+++ b/src/guides/bloodmoon-cult/cultleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Cult Leader
 menu: The Bloodmoon Cult
-route: /cultleader
+route: /roles/CultLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/acolyte.mdx
+++ b/src/guides/coven/acolyte.mdx
@@ -1,7 +1,7 @@
 ---
 name: Acolyte
 menu: The Coven
-route: /acolyte
+route: /roles/Acolyte
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/alchemist.mdx
+++ b/src/guides/coven/alchemist.mdx
@@ -1,7 +1,7 @@
 ---
 name: Alchemist
 menu: The Coven
-route: /alchemist
+route: /roles/Alchemist
 ---
 
 # Alchemist

--- a/src/guides/coven/coven.mdx
+++ b/src/guides/coven/coven.mdx
@@ -1,7 +1,7 @@
 ---
 name: Coven
 menu: The Coven
-route: /coven
+route: /roles/Coven
 ---
 
 # The Coven

--- a/src/guides/coven/djinn.mdx
+++ b/src/guides/coven/djinn.mdx
@@ -1,7 +1,7 @@
 ---
 name: Djinn
 menu: The Coven
-route: /djinn
+route: /roles/Djinn
 ---
 
 # Djinn

--- a/src/guides/coven/furie.mdx
+++ b/src/guides/coven/furie.mdx
@@ -1,7 +1,7 @@
 ---
 name: Furie
 menu: The Coven
-route: /furie
+route: /roles/Furie
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/harpy.mdx
+++ b/src/guides/coven/harpy.mdx
@@ -1,7 +1,7 @@
 ---
 name: Harpy
 menu: The Coven
-route: /harpy
+route: /roles/Harpy
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/puppetmaster.mdx
+++ b/src/guides/coven/puppetmaster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Puppetmaster
 menu: The Coven
-route: /puppetmaster
+route: /roles/Puppetmaster
 ---
 
 # Puppetmaster

--- a/src/guides/coven/shaman.mdx
+++ b/src/guides/coven/shaman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Shaman
 menu: The Coven
-route: /shaman
+route: /roles/Shaman
 ---
 
 # Shaman

--- a/src/guides/coven/succubus.mdx
+++ b/src/guides/coven/succubus.mdx
@@ -1,7 +1,7 @@
 ---
 name: Succubus
 menu: The Coven
-route: /succubus
+route: /roles/Succubus
 ---
 
 # Succubus

--- a/src/guides/coven/warlock.mdx
+++ b/src/guides/coven/warlock.mdx
@@ -1,7 +1,7 @@
 ---
 name: Warlock
 menu: The Coven
-route: /warlock
+route: /roles/Warlock
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/witch.mdx
+++ b/src/guides/coven/witch.mdx
@@ -1,7 +1,7 @@
 ---
 name: Witch
 menu: The Coven
-route: /witch
+route: /roles/Witch
 ---
 
 # Witch

--- a/src/guides/general/basics.mdx
+++ b/src/guides/general/basics.mdx
@@ -1,7 +1,7 @@
 ---
 name: Basics
 menu: General
-route: /
+route: /how-to-play-online-werewolf
 ---
 
 # How to Play Werewolf Online

--- a/src/guides/general/rules.mdx
+++ b/src/guides/general/rules.mdx
@@ -1,7 +1,7 @@
 ---
 name: Rules
 menu: General
-route: /rules
+route: /online-werewolf-rules
 ---
 
 ## Rules

--- a/src/guides/general/tips.mdx
+++ b/src/guides/general/tips.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tips
 menu: General
-route: /tips
+route: /tips-for-playing-werewolf-online
 ---
 
 # Tips

--- a/src/guides/neutral/displaced.mdx
+++ b/src/guides/neutral/displaced.mdx
@@ -1,7 +1,7 @@
 ---
 name: Displaced
 menu: The Neutral
-route: /displaced
+route: /roles/Displaced
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/drunk.mdx
+++ b/src/guides/neutral/drunk.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk
 menu: The Neutral
-route: /drunk
+route: /roles/Drunk
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/essencethief.mdx
+++ b/src/guides/neutral/essencethief.mdx
@@ -1,7 +1,7 @@
 ---
 name: Essence Thief
 menu: The Neutral
-route: /essencethief
+route: /roles/EssenceThief
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/neutral.mdx
+++ b/src/guides/neutral/neutral.mdx
@@ -1,7 +1,7 @@
 ---
 name: Neutral
 menu: The Neutral
-route: /neutral
+route: /roles/Neutral
 ---
 
 # Neutral Roles

--- a/src/guides/neutral/tanner.mdx
+++ b/src/guides/neutral/tanner.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tanner
 menu: The Neutral
-route: /tanner
+route: /roles/Tanner
 ---
 
 # Tanner

--- a/src/guides/undead/banshee.mdx
+++ b/src/guides/undead/banshee.mdx
@@ -1,7 +1,7 @@
 ---
 name: Banshee
 menu: The Undead
-route: /banshee
+route: /roles/Banshee
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/ghoul.mdx
+++ b/src/guides/undead/ghoul.mdx
@@ -1,7 +1,7 @@
 ---
 name: Ghoul
 menu: The Undead
-route: /ghoul
+route: /roles/Ghoul
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/medium.mdx
+++ b/src/guides/undead/medium.mdx
@@ -1,7 +1,7 @@
 ---
 name: Medium
 menu: The Undead
-route: /medium
+route: /roles/Medium
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/necromancer.mdx
+++ b/src/guides/undead/necromancer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Necromancer
 menu: The Undead
-route: /necromancer
+route: /roles/Necromancer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/revenant.mdx
+++ b/src/guides/undead/revenant.mdx
@@ -1,7 +1,7 @@
 ---
 name: Revenant
 menu: The Undead
-route: /revenant
+route: /roles/Revenant
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/undead.mdx
+++ b/src/guides/undead/undead.mdx
@@ -1,7 +1,7 @@
 ---
 name: Undead
 menu: The Undead
-route: /undead
+route: /roles/VoodooDoctor
 ---
 
 # The Undead

--- a/src/guides/undead/voodoodoctor.mdx
+++ b/src/guides/undead/voodoodoctor.mdx
@@ -1,7 +1,7 @@
 ---
 name: Voodoo Doctor
 menu: The Undead
-route: /voodoodoctor
+route: /roles/VoodooDoctor
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/wight.mdx
+++ b/src/guides/undead/wight.mdx
@@ -1,7 +1,7 @@
 ---
 name: Wight
 menu: The Undead
-route: /wight
+route: /roles/Wight
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/vampires/familiar.mdx
+++ b/src/guides/vampires/familiar.mdx
@@ -1,7 +1,7 @@
 ---
 name: Familiar
 menu: The Vampires
-route: /familiar
+route: /roles/Familiar
 ---
 
 # Familiar

--- a/src/guides/vampires/vampire.mdx
+++ b/src/guides/vampires/vampire.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampire
 menu: The Vampires
-route: /vampire
+route: /roles/Vampire
 ---
 
 # Vampire

--- a/src/guides/vampires/vampiremaster.mdx
+++ b/src/guides/vampires/vampiremaster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampire Master
 menu: The Vampires
-route: /vampiremaster
+route: /roles/VampireMaster
 ---
 
 # Vampire Master

--- a/src/guides/vampires/vampires.mdx
+++ b/src/guides/vampires/vampires.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampires
 menu: The Vampires
-route: /vampires
+route: /roles/Vampires
 ---
 
 # The Vampires

--- a/src/guides/village/adjudicator.mdx
+++ b/src/guides/village/adjudicator.mdx
@@ -1,7 +1,7 @@
 ---
 name: Adjudicator
 menu: The Village
-route: /adjudicator
+route: /roles/Adjudicator
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/agitator.mdx
+++ b/src/guides/village/agitator.mdx
@@ -1,7 +1,7 @@
 ---
 name: Agitator
 menu: The Village
-route: /agitator
+route: /roles/Agitator
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/beholder.mdx
+++ b/src/guides/village/beholder.mdx
@@ -1,7 +1,7 @@
 ---
 name: Beholder
 menu: The Village
-route: /beholder
+route: /roles/Beholder
 ---
 
 # Beholder

--- a/src/guides/village/courtesan.mdx
+++ b/src/guides/village/courtesan.mdx
@@ -1,7 +1,7 @@
 ---
 name: Courtesan
 menu: The Village
-route: /courtesan
+route: /roles/Courtesan
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/diseased.mdx
+++ b/src/guides/village/diseased.mdx
@@ -1,7 +1,7 @@
 ---
 name: Diseased
 menu: The Village
-route: /diseased
+route: /roles/Courtesan
 ---
 
 # Diseased

--- a/src/guides/village/drunkharlot.mdx
+++ b/src/guides/village/drunkharlot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk Harlot
 menu: The Village
-route: /drunkharlot
+route: /roles/DrunkHarlot
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/drunkseer.mdx
+++ b/src/guides/village/drunkseer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk Seer
 menu: The Village
-route: /drunkseer
+route: /roles/DrunkSeer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/grandvizier.mdx
+++ b/src/guides/village/grandvizier.mdx
@@ -1,7 +1,7 @@
 ---
 name: Grand Vizier
 menu: The Village
-route: /grandvizier
+route: /roles/GrandVizier
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/gravedigger.mdx
+++ b/src/guides/village/gravedigger.mdx
@@ -1,7 +1,7 @@
 ---
 name: Gravedigger
 menu: The Village
-route: /gravedigger
+route: /roles/Gravedigger
 ---
 
 # Gravedigger

--- a/src/guides/village/graverobber.mdx
+++ b/src/guides/village/graverobber.mdx
@@ -1,7 +1,7 @@
 ---
 name: Graverobber
 menu: The Village
-route: /graverobber
+route: /roles/Graverobber
 ---
 
 # Graverobber

--- a/src/guides/village/gravewarden.mdx
+++ b/src/guides/village/gravewarden.mdx
@@ -1,7 +1,7 @@
 ---
 name: Grave Warden
 menu: The Village
-route: /gravewarden
+route: /roles/GraveWarden
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/harlot.mdx
+++ b/src/guides/village/harlot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Harlot
 menu: The Village
-route: /harlot
+route: /roles/Harlot
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/huntsman.mdx
+++ b/src/guides/village/huntsman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Huntsman
 menu: The Village
-route: /huntsman
+route: /roles/Huntsman
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/illuminatileader.mdx
+++ b/src/guides/village/illuminatileader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Illuminati Leader
 menu: The Village
-route: /illuminatileader
+route: /roles/IlluminatiLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/illuminatilookout.mdx
+++ b/src/guides/village/illuminatilookout.mdx
@@ -1,7 +1,7 @@
 ---
 name: Illuminati Lookout
 menu: The Village
-route: /illuminatilookout
+route: /roles/IlluminatiLookout
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/inquisitionleader.mdx
+++ b/src/guides/village/inquisitionleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Inquisition Leader
 menu: The Village
-route: /inquisitionleader
+route: /roles/InquisitionLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/inquisitor.mdx
+++ b/src/guides/village/inquisitor.mdx
@@ -1,7 +1,7 @@
 ---
 name: Inquisitor
 menu: The Village
-route: /inquisitor
+route: /roles/Inquisitor
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/insomniac.mdx
+++ b/src/guides/village/insomniac.mdx
@@ -1,7 +1,7 @@
 ---
 name: Insomniac
 menu: The Village
-route: /insomniac
+route: /roles/Insomniac
 ---
 
 # Insomniac

--- a/src/guides/village/lycan.mdx
+++ b/src/guides/village/lycan.mdx
@@ -1,7 +1,7 @@
 ---
 name: Lycan
 menu: The Village
-route: /lycan
+route: /roles/Lycan
 ---
 
 # Lycan

--- a/src/guides/village/maplewolf.mdx
+++ b/src/guides/village/maplewolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Maple Wolf
 menu: The Village
-route: /maplewolf
+route: /roles/MapleWolf
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/masonleader.mdx
+++ b/src/guides/village/masonleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mason Leader
 menu: The Village
-route: /masonleader
+route: /roles/MasonLeader
 ---
 
 # Mason Leader

--- a/src/guides/village/masonsergeant.mdx
+++ b/src/guides/village/masonsergeant.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mason Sergeant
 menu: The Village
-route: /masonsergeant
+route: /roles/MasonSergeant
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/messiah.mdx
+++ b/src/guides/village/messiah.mdx
@@ -1,7 +1,7 @@
 ---
 name: Messiah
 menu: The Village
-route: /messiah
+route: /roles/Messiah
 ---
 
 # Messiah

--- a/src/guides/village/militia.mdx
+++ b/src/guides/village/militia.mdx
@@ -1,7 +1,7 @@
 ---
 name: Militia
 menu: The Village
-route: /militia
+route: /roles/Militia
 ---
 
 # Militia

--- a/src/guides/village/mortician.mdx
+++ b/src/guides/village/mortician.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mortician
 menu: The Village
-route: /mortician
+route: /roles/Mortician
 ---
 
 # Mortician

--- a/src/guides/village/novicetarotreader.mdx
+++ b/src/guides/village/novicetarotreader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Novice Tarot Reader
 menu: The Village
-route: /novicetarotreader
+route: /roles/NoviceTarotReader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/protector.mdx
+++ b/src/guides/village/protector.mdx
@@ -1,7 +1,7 @@
 ---
 name: Protector
 menu: The Village
-route: /protector
+route: /roles/Protector
 ---
 
 # Protector

--- a/src/guides/village/purifier.mdx
+++ b/src/guides/village/purifier.mdx
@@ -1,7 +1,7 @@
 ---
 name: Purifier
 menu: The Village
-route: /purifier
+route: /roles/Purifier
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/reviver.mdx
+++ b/src/guides/village/reviver.mdx
@@ -1,7 +1,7 @@
 ---
 name: Reviver
 menu: The Village
-route: /reviver
+route: /roles/Reviver
 ---
 
 # Reviver

--- a/src/guides/village/runesmith.mdx
+++ b/src/guides/village/runesmith.mdx
@@ -1,7 +1,7 @@
 ---
 name: Rune Smith
 menu: The Village
-route: /runesmith
+route: /roles/RuneSmith
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/seer.mdx
+++ b/src/guides/village/seer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Seer
 menu: The Village
-route: /seer
+route: /roles/Seer
 ---
 
 ## Seer

--- a/src/guides/village/sleepwalker.mdx
+++ b/src/guides/village/sleepwalker.mdx
@@ -1,7 +1,7 @@
 ---
 name: Sleepwalker
 menu: The Village
-route: /sleepwalker
+route: /roles/Sleepwalker
 ---
 
 # Sleepwalker

--- a/src/guides/village/stalker.mdx
+++ b/src/guides/village/stalker.mdx
@@ -1,7 +1,7 @@
 ---
 name: Stalker
 menu: The Village
-route: /stalker
+route: /roles/Stalker
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/strongman.mdx
+++ b/src/guides/village/strongman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Strongman
 menu: The Village
-route: /strongman
+route: /roles/Strongman
 ---
 
 # Strongman

--- a/src/guides/village/tarotreader.mdx
+++ b/src/guides/village/tarotreader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tarot Reader
 menu: The Village
-route: /tarotreader
+route: /roles/TarotReader
 ---
 
 # Tarot Reader

--- a/src/guides/village/thief.mdx
+++ b/src/guides/village/thief.mdx
@@ -1,7 +1,7 @@
 ---
 name: Thief
 menu: The Village
-route: /thief
+route: /roles/Thief
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/village.mdx
+++ b/src/guides/village/village.mdx
@@ -1,7 +1,7 @@
 ---
 name: Village
 menu: The Village
-route: /village
+route: /roles/Village
 ---
 
 # The Village

--- a/src/guides/village/villager.mdx
+++ b/src/guides/village/villager.mdx
@@ -1,7 +1,7 @@
 ---
 name: Villager
 menu: The Village
-route: /villager
+route: /roles/Villager
 ---
 
 # Villager

--- a/src/guides/village/witchhunter.mdx
+++ b/src/guides/village/witchhunter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Witch Hunter
 menu: The Village
-route: /witchhunter
+route: /roles/WitchHunter
 ---
 
 # Witch Hunter

--- a/src/guides/village/zealot.mdx
+++ b/src/guides/village/zealot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Zealot
 menu: The Village
-route: /zealot
+route: /roles/Zealot
 ---
 
 # Zealot

--- a/src/guides/wolfpack/alphawolf.mdx
+++ b/src/guides/wolfpack/alphawolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Alphawolf
 menu: The Wolfpack
-route: /alphawolf
+route: /roles/Alphawolf
 ---
 
 # Alphawolf

--- a/src/guides/wolfpack/bloodhound.mdx
+++ b/src/guides/wolfpack/bloodhound.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodhound
 menu: The Wolfpack
-route: /bloodhound
+route: /roles/Bloodhound
 ---
 
 # Bloodhound

--- a/src/guides/wolfpack/bloodletter.mdx
+++ b/src/guides/wolfpack/bloodletter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodletter
 menu: The Wolfpack
-route: /bloodletter
+route: /roles/Bloodletter
 ---
 
 # Bloodletter

--- a/src/guides/wolfpack/bloodthirster.mdx
+++ b/src/guides/wolfpack/bloodthirster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodthirster
 menu: The Wolfpack
-route: /bloodthirster
+route: /roles/Bloodthirster
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/wolfpack/direwolf.mdx
+++ b/src/guides/wolfpack/direwolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Direwolf
 menu: The Wolfpack
-route: /direwolf
+route: /roles/Direwolf
 ---
 
 # Direwolf

--- a/src/guides/wolfpack/omegawolf.mdx
+++ b/src/guides/wolfpack/omegawolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Omegawolf
 menu: The Wolfpack
-route: /omegawolf
+route: /roles/Omegawolf
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/wolfpack/shapeshifter.mdx
+++ b/src/guides/wolfpack/shapeshifter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Shapeshifter
 menu: The Wolfpack
-route: /shapeshifter
+route: /roles/Shapeshifter
 ---
 
 # Shapeshifter

--- a/src/guides/wolfpack/werewolf.mdx
+++ b/src/guides/wolfpack/werewolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Werewolf
 menu: The Wolfpack
-route: /werewolf
+route: /roles/Werewolf
 ---
 
 # Werewolf

--- a/src/guides/wolfpack/wolfpack.mdx
+++ b/src/guides/wolfpack/wolfpack.mdx
@@ -1,7 +1,7 @@
 ---
 name: Wolfpack
 menu: The Wolfpack
-route: /wolfpack
+route: /roles/Werewolf
 ---
 
 # The Wolfpack


### PR DESCRIPTION
Thinking from an SEO Point of view, we probably want to retain the old URLs so that the existing google indexed pages don't suddenly 404 when we switch over to this.

(Side-Note on SEO: I'm not convinced the side-bar menu is super seo-friendly as the different sections are loaded in with JS not in the raw HTML. I don't know if gatsby/docz is doing something else somewhere to make that work better or if google et-all are more intelligent these days such that it won't matter.)

I'm assuming @Kirschstein will be proxying `/guides/` to this, so have put everything else under their old URLs (eg `/roles/Djinn`) etc and I assume the proxy will magically rewrite things to include the `/guides` bit.

Some minor things that I couldn't sort:

1) I can't have the basics page on both `/` and `/how-to-play-online-werewolf`. If I set it to `/how-to-play-online-werewolf` then `/` ends up being the BloodMoon Cult page instead for some reason. Maybe we can put basics on `/how-to-play-online-werewolf` and then have a generic "Welcome to the how to play" page on `/`?

2) URLs are case-sensitive, they used to be case-insensitive on the old embedded site.