### PR TITLE
Clarifying Shapeshifter visits

### DIFF
--- a/src/guides/wolfpack/shapeshifter.mdx
+++ b/src/guides/wolfpack/shapeshifter.mdx
@@ -13,14 +13,14 @@ The Shapeshifter is a powerful werewolf, able to turn the tide of an otherwise h
 - The Shapeshifter, both before and after he shifts, is seen as a member of the Wolfpack by the Seer.
 - The Shapeshifter is seen as a user of witchcraft.
 - The Shapeshifter is seen visiting by the Harlot/Stalker/Familiar when they are the killing wolf.
-- The Shapeshifter's secondary ability - activating the identity swap of their shift is classed as a self visit but is only seen by the Harlot.
+- The Shapeshifter's secondary ability - activating the identity swap of their shift - is classed as a self visit.
 - The Shapeshifter is seen as a killer by the Adjudicator.
 
 ## Notes
 
-- The Shapeshifter's ability does NOT grant an extra kill to the Wolfpack. Their ability (only) works on the wolfpack's regular nightly kill.
+- The Shapeshifter's ability does NOT grant an extra kill to the Wolfpack. Their ability only works on the wolfpack's regular nightly kill.
 - The Shapeshifter does not have to be the killing wolf in order to shift. While the Shapeshifter is seen visiting if they are the killing wolf, their shift can also take place without them being seen visiting the person they shift into, if another wolf is the killing wolf.
-- The Shapeshifter visits themselves the night of their shift, regardless whether they are (not) the killing wolf, but is only seen by the Harlot. The Stalker will only see an external visit, not the self visit.
+- The Shapeshifter visits themselves the night of their shift, regardless whether they are (not) the killing wolf. Like all self-visits, this is seen by the Harlot.
 - Once the Shapeshifter has used their ability, they revert into a normal Werewolf. If a Witch Hunter has checked the Shapeshifter before their shift the mark remains, and the Witch Hunter may be aware of the shift. If a Witch Hunter checks a Shapeshifter only after their shift, however, all the rules for the normal Werewolf apply.
 - The Shapeshifter can only shift into the regular wolf kill's victim, not the Alphawolf's extra victim targeted with their Enrage ability, even if the regular wolf kill is prevented in some way and the Alphawolf's kill is not.
 

--- a/src/guides/wolfpack/shapeshifter.mdx
+++ b/src/guides/wolfpack/shapeshifter.mdx
@@ -13,14 +13,14 @@ The Shapeshifter is a powerful werewolf, able to turn the tide of an otherwise h
 - The Shapeshifter, both before and after he shifts, is seen as a member of the Wolfpack by the Seer.
 - The Shapeshifter is seen as a user of witchcraft.
 - The Shapeshifter is seen visiting by the Harlot/Stalker/Familiar when they are the killing wolf.
-- The Shapeshifter's secondary ability - activating the identity swap of their shift is classed as a self visit.
+- The Shapeshifter's secondary ability - activating the identity swap of their shift is classed as a self visit but is only seen by the Harlot.
 - The Shapeshifter is seen as a killer by the Adjudicator.
 
 ## Notes
 
 - The Shapeshifter's ability does NOT grant an extra kill to the Wolfpack. Their ability (only) works on the wolfpack's regular nightly kill.
 - The Shapeshifter does not have to be the killing wolf in order to shift. While the Shapeshifter is seen visiting if they are the killing wolf, their shift can also take place without them being seen visiting the person they shift into, if another wolf is the killing wolf.
-- The Shapeshifter is seen visiting themselves the night of their shift, regardless whether they are (not) the killing wolf.
+- The Shapeshifter visits themselves the night of their shift, regardless whether they are (not) the killing wolf, but is only seen by the Harlot. The Stalker will only see an external visit, not the self visit.
 - Once the Shapeshifter has used their ability, they revert into a normal Werewolf. If a Witch Hunter has checked the Shapeshifter before their shift the mark remains, and the Witch Hunter may be aware of the shift. If a Witch Hunter checks a Shapeshifter only after their shift, however, all the rules for the normal Werewolf apply.
 - The Shapeshifter can only shift into the regular wolf kill's victim, not the Alphawolf's extra victim targeted with their Enrage ability, even if the regular wolf kill is prevented in some way and the Alphawolf's kill is not.
 


### PR DESCRIPTION
# Description

Stating that SS self visits are only seen by the harlot.

# Checklist

I have checked the following _(mark as completed with [x])_:

- [ ] The content is accurate (and confirmed with the mods)
- [ ] Casing and wording of keywords such as role names, factions, etc, is all correct
- [ ] The Markdown is valid
- [ ] It renders correctly _(follow README for instructions on previewing)_
- [ ] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
