### PR TITLE
Fix Diseased/Courtesan linking

### DIFF
--- a/src/guides/undead/undead.mdx
+++ b/src/guides/undead/undead.mdx
@@ -1,7 +1,7 @@
 ---
 name: Undead
 menu: The Undead
-route: roles/VoodooDoctor
+route: roles/Undead
 ---
 
 # The Undead

--- a/src/guides/village/diseased.mdx
+++ b/src/guides/village/diseased.mdx
@@ -1,7 +1,7 @@
 ---
 name: Diseased
 menu: The Village
-route: roles/Courtesan
+route: roles/Diseased
 ---
 
 # Diseased

--- a/src/guides/village/seer.mdx
+++ b/src/guides/village/seer.mdx
@@ -4,7 +4,7 @@ menu: The Village
 route: roles/Seer
 ---
 
-## Seer
+# Seer
 
 Once per night, the Seer can check a player and will learn their alignment in the morning.
 


### PR DESCRIPTION
# Description

Fixing the courtesan page linking to diseased.

# Checklist

I have checked the following _(mark as completed with [x])_:

- [ ] The content is accurate (and confirmed with the mods)
- [ ] Casing and wording of keywords such as role names, factions, etc, is all correct
- [ ] The Markdown is valid
- [ ] It renders correctly _(follow README for instructions on previewing)_
- [ ] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
