### PR TITLE
Fix trailing slash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# gatsby/docz files
+.cache/
+.docz/
+public/
+
+# dependencies
+node_modules/
+
+# environment files
+.envrc

--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,4 +1,5 @@
 FROM nginx:mainline-alpine AS nginx
+COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./public/ /usr/share/nginx/html
 RUN ln -sf /usr/share/nginx/html /usr/share/nginx/html/guides
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY static /app/static
 RUN npm run build
 
 FROM nginx:mainline-alpine AS nginx
+COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/public/ /usr/share/nginx/html
 RUN ln -sf /usr/share/nginx/html /usr/share/nginx/html/guides
 EXPOSE 80

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    server_name  wwes-h2p;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page  404              /404.html;
+    location = /404.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,7 +4,9 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        index  index.html;
+        absolute_redirect off;
+        try_files $uri $uri/index.html $uri/ =404;
     }
 
     error_page  404              /404.html;


### PR DESCRIPTION
# Description

This fixes the nginx install in the docker containers to consider requests for `/guides/roles/Werewolf` to be the same as `/guides/roles/Werewolf/index.html` which is what gatsby actually generates.
