### PR TITLE
Actually raw link to / not to gatsbys impresssion of /.

### DIFF
--- a/src/gatsby-theme-docz/components/Header/index.js
+++ b/src/gatsby-theme-docz/components/Header/index.js
@@ -29,9 +29,9 @@ export const Header = props => {
       <div sx={styles.innerContainer}>
         <Flex>
           <Logo />
-          <Link to="/" sx={styles.link}>
+          <a href="/" sx={styles.link}>
             Lobby
-          </Link>
+          </a>
         </Flex>
         <Flex>
           {repository && (


### PR DESCRIPTION
# Description

This makes the lobby link an actual `<a href="/">` and not have it interpreted by gastby as a link to the gatsby root.