### PR TITLE
We need to allow public/ in the build context for the deployment build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 # gatsby/docz files
 .cache/
 .docz/
-public/
 
 # dependencies
 node_modules/


### PR DESCRIPTION
# Description

The `.dockerignore` file was fine for full builds as they pulled `/public` from a build container, but when deploying from github the build happens in a separate action step so we need access to `public/` in the build context.