### PR TITLE
Update dove card definiton

### DIFF
--- a/src/guides/village/novicetarotreader.mdx
+++ b/src/guides/village/novicetarotreader.mdx
@@ -8,9 +8,9 @@ import { Timeline, Event } from 'react-trivial-timeline';
 
 # Novice Tarot Reader
 
-The Novice Tarot Reader is a member of the Village. They are able to select two players at night to draw cards from. Five cards will be drawn, two of which correspond to each player chosen. A random card will be drawn that corresponds to a random player. The order of the cards drawn are randomized.
+The Novice Tarot Reader is a member of the Village. They are able to select two players at night to draw cards from. Five cards will be drawn, two of which correspond to each player chosen. A random card will be drawn that corresponds to a random player in that game. The order of the cards drawn are randomized.
 
-Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, two examples are Dove and Magician cards. The Dove card may come from alignment meaning "Village member", or from killing ability meaning "not a killer". The Magician card may come from alignment meaning "Coven member", or from witch status, meaning "user of witchcraft".
+Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, two examples are Dove and Magician cards. The Dove card may come from alignment meaning "Village member", or from killing ability meaning "not a killer". The Magician card may come from alignment meaning "Coven member", or from Witchcraft status, meaning "user of Witchcraft".
 
 ## Alignment Cards
 

--- a/src/guides/village/novicetarotreader.mdx
+++ b/src/guides/village/novicetarotreader.mdx
@@ -10,7 +10,7 @@ import { Timeline, Event } from 'react-trivial-timeline';
 
 The Novice Tarot Reader is a member of the Village. They are able to select two players at night to draw cards from. Five cards will be drawn, two of which correspond to each player chosen. A random card will be drawn that corresponds to a random player. The order of the cards drawn are randomized.
 
-Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, for example, Dove meaning either a non-killer or a Village member, or Magician meaning either a witchcraft user or a Coven member.
+Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, two examples are Dove and Magician cards. The Dove card may come from alignment meaning "Village member", or from killing ability meaning "not a killer". The Magician card may come from alignment meaning "Coven member", or from witch status, meaning "user of witchcraft".
 
 ## Alignment Cards
 

--- a/src/guides/village/novicetarotreader.mdx
+++ b/src/guides/village/novicetarotreader.mdx
@@ -10,12 +10,12 @@ import { Timeline, Event } from 'react-trivial-timeline';
 
 The Novice Tarot Reader is a member of the Village. They are able to select two players at night to draw cards from. Five cards will be drawn, two of which correspond to each player chosen. A random card will be drawn that corresponds to a random player. The order of the cards drawn are randomized.
 
-Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, for example, Magician meaning both a witchcraft user and a Coven member.
+Each card reflects one of three facets - alignment, killing ability, and witchcraft status. There are some cards that can be interpreted in two ways, for example, Dove meaning either a non-killer or a Village member, or Magician meaning either a witchcraft user or a Coven member.
 
 ## Alignment Cards
 
 <dl>
-  <dt>Innocence</dt>
+  <dt>Dove</dt>
   <dd>A member of the Village, or the Direwolf</dd>
   <dt>Hound</dt>
   <dd>A member of the Wolfpack, Blood Moon Cult, or a Lycan Villager</dd>


### PR DESCRIPTION
# Description

Show village correctly as being the dove card.

# Checklist

I have checked the following _(mark as completed with [x])_:

- [ ] The content is accurate (and confirmed with the mods)
- [ ] Casing and wording of keywords such as role names, factions, etc, is all correct
- [ ] The Markdown is valid
- [ ] It renders correctly _(follow README for instructions on previewing)_
- [ ] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
