### PR TITLE
Add root-relative paths for all `route: ` entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Guide files are stored within `docs`. Each guide is written in Markdown and has 
 ---
 name: Cupid
 menu: The Neutral
-route: guides/cupid
+route: /guides/cupid
 ---
 
 # Cupid

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,5 +1,5 @@
 export default {
-  base: '/guides/',
+  base: '/',
   description: 'How to Play guide for werewolv.es',
   editBranch: 'site',
   files: 'src/**/*.{md,markdown,mdx}',

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -6331,6 +6332,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -7950,6 +7952,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.2",
@@ -12682,6 +12693,12 @@
       "version": "12.4.2",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
       "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -28052,6 +28069,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -28527,6 +28545,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/src/guides/aaa_general/aaa_basics.mdx
+++ b/src/guides/aaa_general/aaa_basics.mdx
@@ -1,7 +1,7 @@
 ---
 name: Basics
 menu: General
-route: how-to-play-online-werewolf
+route: /how-to-play-online-werewolf
 ---
 
 # How to Play Werewolf Online

--- a/src/guides/aaa_general/buttons-and-abilities.mdx
+++ b/src/guides/aaa_general/buttons-and-abilities.mdx
@@ -1,7 +1,7 @@
 ---
 name: Buttons & Abilities
 menu: General
-route: buttons-and-abilities
+route: /buttons-and-abilities
 ---
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/guides/aaa_general/community-guidelines.mdx
+++ b/src/guides/aaa_general/community-guidelines.mdx
@@ -1,7 +1,7 @@
 ---
 name: Community Guidelines
 menu: General
-route: community-guidelines
+route: /community-guidelines
 ---
 
 # Community Guidelines

--- a/src/guides/aaa_general/items.mdx
+++ b/src/guides/aaa_general/items.mdx
@@ -1,7 +1,7 @@
 ---
 name: Items
 menu: General
-route: items
+route: /items
 ---
 
 # Items in werewolv.es

--- a/src/guides/aaa_general/rules.mdx
+++ b/src/guides/aaa_general/rules.mdx
@@ -1,7 +1,7 @@
 ---
 name: Rules
 menu: General
-route: online-werewolf-rules
+route: /online-werewolf-rules
 ---
 
 ## Rules

--- a/src/guides/aaa_general/tips.mdx
+++ b/src/guides/aaa_general/tips.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tips
 menu: General
-route: tips-for-playing-werewolf-online
+route: /tips-for-playing-werewolf-online
 ---
 
 # Tips

--- a/src/guides/aaa_general/victory-conditions.mdx
+++ b/src/guides/aaa_general/victory-conditions.mdx
@@ -1,7 +1,7 @@
 ---
 name: Victory Conditions
 menu: General
-route: victory-conditions
+route: /victory-conditions
 ---
 
 # Victory Conditions

--- a/src/guides/bloodmoon-cult/bloodmoon-cult.mdx
+++ b/src/guides/bloodmoon-cult/bloodmoon-cult.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodmoon Cult
 menu: The Bloodmoon Cult
-route: roles/BloodmoonCult
+route: /roles/BloodmoonCult
 ---
 
 # Bloodmoon Cult

--- a/src/guides/bloodmoon-cult/bloodpriest.mdx
+++ b/src/guides/bloodmoon-cult/bloodpriest.mdx
@@ -1,7 +1,7 @@
 ---
 name: Blood Priest
 menu: The Bloodmoon Cult
-route: roles/BloodPriest
+route: /roles/BloodPriest
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/bloodmoon-cult/bloodseer.mdx
+++ b/src/guides/bloodmoon-cult/bloodseer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Blood Seer
 menu: The Bloodmoon Cult
-route: roles/BloodSeer
+route: /roles/BloodSeer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/bloodmoon-cult/cultfollower.mdx
+++ b/src/guides/bloodmoon-cult/cultfollower.mdx
@@ -1,7 +1,7 @@
 ---
 name: Cult Follower
 menu: The Bloodmoon Cult
-route: roles/CultFollower
+route: /roles/CultFollower
 ---
 
 # Cult Follower

--- a/src/guides/bloodmoon-cult/cultleader.mdx
+++ b/src/guides/bloodmoon-cult/cultleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Cult Leader
 menu: The Bloodmoon Cult
-route: roles/CultLeader
+route: /roles/CultLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/acolyte.mdx
+++ b/src/guides/coven/acolyte.mdx
@@ -1,7 +1,7 @@
 ---
 name: Acolyte
 menu: The Coven
-route: roles/Acolyte
+route: /roles/Acolyte
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/alchemist.mdx
+++ b/src/guides/coven/alchemist.mdx
@@ -1,7 +1,7 @@
 ---
 name: Alchemist
 menu: The Coven
-route: roles/Alchemist
+route: /roles/Alchemist
 ---
 
 # Alchemist

--- a/src/guides/coven/coven.mdx
+++ b/src/guides/coven/coven.mdx
@@ -1,7 +1,7 @@
 ---
 name: Coven
 menu: The Coven
-route: roles/Coven
+route: /roles/Coven
 ---
 
 # The Coven

--- a/src/guides/coven/djinn.mdx
+++ b/src/guides/coven/djinn.mdx
@@ -1,7 +1,7 @@
 ---
 name: Djinn
 menu: The Coven
-route: roles/Djinn
+route: /roles/Djinn
 ---
 
 # Djinn

--- a/src/guides/coven/furie.mdx
+++ b/src/guides/coven/furie.mdx
@@ -1,7 +1,7 @@
 ---
 name: Furie
 menu: The Coven
-route: roles/Furie
+route: /roles/Furie
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/harpy.mdx
+++ b/src/guides/coven/harpy.mdx
@@ -1,7 +1,7 @@
 ---
 name: Harpy
 menu: The Coven
-route: roles/Harpy
+route: /roles/Harpy
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/puppetmaster.mdx
+++ b/src/guides/coven/puppetmaster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Puppetmaster
 menu: The Coven
-route: roles/Puppetmaster
+route: /roles/Puppetmaster
 ---
 
 # Puppetmaster

--- a/src/guides/coven/shaman.mdx
+++ b/src/guides/coven/shaman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Shaman
 menu: The Coven
-route: roles/Shaman
+route: /roles/Shaman
 ---
 
 # Shaman

--- a/src/guides/coven/succubus.mdx
+++ b/src/guides/coven/succubus.mdx
@@ -1,7 +1,7 @@
 ---
 name: Succubus
 menu: The Coven
-route: roles/Succubus
+route: /roles/Succubus
 ---
 
 # Succubus

--- a/src/guides/coven/warlock.mdx
+++ b/src/guides/coven/warlock.mdx
@@ -1,7 +1,7 @@
 ---
 name: Warlock
 menu: The Coven
-route: roles/Warlock
+route: /roles/Warlock
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/coven/witch.mdx
+++ b/src/guides/coven/witch.mdx
@@ -1,7 +1,7 @@
 ---
 name: Witch
 menu: The Coven
-route: roles/Witch
+route: /roles/Witch
 ---
 
 # Witch

--- a/src/guides/neutral/displaced.mdx
+++ b/src/guides/neutral/displaced.mdx
@@ -1,7 +1,7 @@
 ---
 name: Displaced
 menu: The Neutral
-route: roles/Displaced
+route: /roles/Displaced
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/drunk.mdx
+++ b/src/guides/neutral/drunk.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk
 menu: The Neutral
-route: roles/Drunk
+route: /roles/Drunk
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/essencethief.mdx
+++ b/src/guides/neutral/essencethief.mdx
@@ -1,7 +1,7 @@
 ---
 name: Essence Thief
 menu: The Neutral
-route: roles/EssenceThief
+route: /roles/EssenceThief
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/neutral/graverobber.mdx
+++ b/src/guides/neutral/graverobber.mdx
@@ -1,7 +1,7 @@
 ---
 name: Graverobber
 menu: The Neutral
-route: roles/Graverobber
+route: /roles/Graverobber
 ---
 
 # Graverobber

--- a/src/guides/neutral/neutral.mdx
+++ b/src/guides/neutral/neutral.mdx
@@ -1,7 +1,7 @@
 ---
 name: Neutral
 menu: The Neutral
-route: roles/Neutral
+route: /roles/Neutral
 ---
 
 # Neutral Roles

--- a/src/guides/neutral/tanner.mdx
+++ b/src/guides/neutral/tanner.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tanner
 menu: The Neutral
-route: roles/Tanner
+route: /roles/Tanner
 ---
 
 # Tanner

--- a/src/guides/undead/banshee.mdx
+++ b/src/guides/undead/banshee.mdx
@@ -1,7 +1,7 @@
 ---
 name: Banshee
 menu: The Undead
-route: roles/Banshee
+route: /roles/Banshee
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/ghoul.mdx
+++ b/src/guides/undead/ghoul.mdx
@@ -1,7 +1,7 @@
 ---
 name: Ghoul
 menu: The Undead
-route: roles/Ghoul
+route: /roles/Ghoul
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/medium.mdx
+++ b/src/guides/undead/medium.mdx
@@ -1,7 +1,7 @@
 ---
 name: Medium
 menu: The Undead
-route: roles/Medium
+route: /roles/Medium
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/necromancer.mdx
+++ b/src/guides/undead/necromancer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Necromancer
 menu: The Undead
-route: roles/Necromancer
+route: /roles/Necromancer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/revenant.mdx
+++ b/src/guides/undead/revenant.mdx
@@ -1,7 +1,7 @@
 ---
 name: Revenant
 menu: The Undead
-route: roles/Revenant
+route: /roles/Revenant
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/undead.mdx
+++ b/src/guides/undead/undead.mdx
@@ -1,7 +1,7 @@
 ---
 name: Undead
 menu: The Undead
-route: roles/Undead
+route: /roles/Undead
 ---
 
 # The Undead

--- a/src/guides/undead/voodoodoctor.mdx
+++ b/src/guides/undead/voodoodoctor.mdx
@@ -1,7 +1,7 @@
 ---
 name: Voodoo Doctor
 menu: The Undead
-route: roles/VoodooDoctor
+route: /roles/VoodooDoctor
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/undead/wight.mdx
+++ b/src/guides/undead/wight.mdx
@@ -1,7 +1,7 @@
 ---
 name: Wight
 menu: The Undead
-route: roles/Wight
+route: /roles/Wight
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/vampires/familiar.mdx
+++ b/src/guides/vampires/familiar.mdx
@@ -1,7 +1,7 @@
 ---
 name: Familiar
 menu: The Vampires
-route: roles/Familiar
+route: /roles/Familiar
 ---
 
 # Familiar

--- a/src/guides/vampires/vampire.mdx
+++ b/src/guides/vampires/vampire.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampire
 menu: The Vampires
-route: roles/Vampire
+route: /roles/Vampire
 ---
 
 # Vampire

--- a/src/guides/vampires/vampiremaster.mdx
+++ b/src/guides/vampires/vampiremaster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampire Master
 menu: The Vampires
-route: roles/VampireMaster
+route: /roles/VampireMaster
 ---
 
 # Vampire Master

--- a/src/guides/vampires/vampires.mdx
+++ b/src/guides/vampires/vampires.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vampires
 menu: The Vampires
-route: roles/Vampires
+route: /roles/Vampires
 ---
 
 # The Vampires

--- a/src/guides/village/adjudicator.mdx
+++ b/src/guides/village/adjudicator.mdx
@@ -1,7 +1,7 @@
 ---
 name: Adjudicator
 menu: The Village
-route: roles/Adjudicator
+route: /roles/Adjudicator
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/agitator.mdx
+++ b/src/guides/village/agitator.mdx
@@ -1,7 +1,7 @@
 ---
 name: Agitator
 menu: The Village
-route: roles/Agitator
+route: /roles/Agitator
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/beholder.mdx
+++ b/src/guides/village/beholder.mdx
@@ -1,7 +1,7 @@
 ---
 name: Beholder
 menu: The Village
-route: roles/Beholder
+route: /roles/Beholder
 ---
 
 # Beholder

--- a/src/guides/village/courtesan.mdx
+++ b/src/guides/village/courtesan.mdx
@@ -1,7 +1,7 @@
 ---
 name: Courtesan
 menu: The Village
-route: roles/Courtesan
+route: /roles/Courtesan
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/diseased.mdx
+++ b/src/guides/village/diseased.mdx
@@ -1,7 +1,7 @@
 ---
 name: Diseased
 menu: The Village
-route: roles/Diseased
+route: /roles/Diseased
 ---
 
 # Diseased

--- a/src/guides/village/drunkharlot.mdx
+++ b/src/guides/village/drunkharlot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk Harlot
 menu: The Village
-route: roles/DrunkHarlot
+route: /roles/DrunkHarlot
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/drunkseer.mdx
+++ b/src/guides/village/drunkseer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Drunk Seer
 menu: The Village
-route: roles/DrunkSeer
+route: /roles/DrunkSeer
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/grandvizier.mdx
+++ b/src/guides/village/grandvizier.mdx
@@ -1,7 +1,7 @@
 ---
 name: Grand Vizier
 menu: The Village
-route: roles/GrandVizier
+route: /roles/GrandVizier
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/gravedigger.mdx
+++ b/src/guides/village/gravedigger.mdx
@@ -1,7 +1,7 @@
 ---
 name: Gravedigger
 menu: The Village
-route: roles/Gravedigger
+route: /roles/Gravedigger
 ---
 
 # Gravedigger

--- a/src/guides/village/gravewarden.mdx
+++ b/src/guides/village/gravewarden.mdx
@@ -1,7 +1,7 @@
 ---
 name: Grave Warden
 menu: The Village
-route: roles/GraveWarden
+route: /roles/GraveWarden
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/harlot.mdx
+++ b/src/guides/village/harlot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Harlot
 menu: The Village
-route: roles/Harlot
+route: /roles/Harlot
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/huntsman.mdx
+++ b/src/guides/village/huntsman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Huntsman
 menu: The Village
-route: roles/Huntsman
+route: /roles/Huntsman
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/illuminatileader.mdx
+++ b/src/guides/village/illuminatileader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Illuminati Leader
 menu: The Village
-route: roles/IlluminatiLeader
+route: /roles/IlluminatiLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/illuminatilookout.mdx
+++ b/src/guides/village/illuminatilookout.mdx
@@ -1,7 +1,7 @@
 ---
 name: Illuminati Lookout
 menu: The Village
-route: roles/IlluminatiLookout
+route: /roles/IlluminatiLookout
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/inquisitionleader.mdx
+++ b/src/guides/village/inquisitionleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Inquisition Leader
 menu: The Village
-route: roles/InquisitionLeader
+route: /roles/InquisitionLeader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/inquisitor.mdx
+++ b/src/guides/village/inquisitor.mdx
@@ -1,7 +1,7 @@
 ---
 name: Inquisitor
 menu: The Village
-route: roles/Inquisitor
+route: /roles/Inquisitor
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/insomniac.mdx
+++ b/src/guides/village/insomniac.mdx
@@ -1,7 +1,7 @@
 ---
 name: Insomniac
 menu: The Village
-route: roles/Insomniac
+route: /roles/Insomniac
 ---
 
 # Insomniac

--- a/src/guides/village/lycan.mdx
+++ b/src/guides/village/lycan.mdx
@@ -1,7 +1,7 @@
 ---
 name: Lycan
 menu: The Village
-route: roles/Lycan
+route: /roles/Lycan
 ---
 
 # Lycan

--- a/src/guides/village/maplewolf.mdx
+++ b/src/guides/village/maplewolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Maple Wolf
 menu: The Village
-route: roles/MapleWolf
+route: /roles/MapleWolf
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/masonleader.mdx
+++ b/src/guides/village/masonleader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mason Leader
 menu: The Village
-route: roles/MasonLeader
+route: /roles/MasonLeader
 ---
 
 # Mason Leader

--- a/src/guides/village/masonsergeant.mdx
+++ b/src/guides/village/masonsergeant.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mason Sergeant
 menu: The Village
-route: roles/MasonSergeant
+route: /roles/MasonSergeant
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/messiah.mdx
+++ b/src/guides/village/messiah.mdx
@@ -1,7 +1,7 @@
 ---
 name: Messiah
 menu: The Village
-route: roles/Messiah
+route: /roles/Messiah
 ---
 
 # Messiah

--- a/src/guides/village/militia.mdx
+++ b/src/guides/village/militia.mdx
@@ -1,7 +1,7 @@
 ---
 name: Militia
 menu: The Village
-route: roles/Militia
+route: /roles/Militia
 ---
 
 # Militia

--- a/src/guides/village/mortician.mdx
+++ b/src/guides/village/mortician.mdx
@@ -1,7 +1,7 @@
 ---
 name: Mortician
 menu: The Village
-route: roles/Mortician
+route: /roles/Mortician
 ---
 
 # Mortician

--- a/src/guides/village/novicetarotreader.mdx
+++ b/src/guides/village/novicetarotreader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Novice Tarot Reader
 menu: The Village
-route: roles/NoviceTarotReader
+route: /roles/NoviceTarotReader
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/protector.mdx
+++ b/src/guides/village/protector.mdx
@@ -1,7 +1,7 @@
 ---
 name: Protector
 menu: The Village
-route: roles/Protector
+route: /roles/Protector
 ---
 
 # Protector

--- a/src/guides/village/purifier.mdx
+++ b/src/guides/village/purifier.mdx
@@ -1,7 +1,7 @@
 ---
 name: Purifier
 menu: The Village
-route: roles/Purifier
+route: /roles/Purifier
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/reviver.mdx
+++ b/src/guides/village/reviver.mdx
@@ -1,7 +1,7 @@
 ---
 name: Reviver
 menu: The Village
-route: roles/Reviver
+route: /roles/Reviver
 ---
 
 # Reviver

--- a/src/guides/village/runesmith.mdx
+++ b/src/guides/village/runesmith.mdx
@@ -1,7 +1,7 @@
 ---
 name: Rune Smith
 menu: The Village
-route: roles/RuneSmith
+route: /roles/RuneSmith
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/seer.mdx
+++ b/src/guides/village/seer.mdx
@@ -1,7 +1,7 @@
 ---
 name: Seer
 menu: The Village
-route: roles/Seer
+route: /roles/Seer
 ---
 
 # Seer

--- a/src/guides/village/sleepwalker.mdx
+++ b/src/guides/village/sleepwalker.mdx
@@ -1,7 +1,7 @@
 ---
 name: Sleepwalker
 menu: The Village
-route: roles/Sleepwalker
+route: /roles/Sleepwalker
 ---
 
 # Sleepwalker

--- a/src/guides/village/stalker.mdx
+++ b/src/guides/village/stalker.mdx
@@ -1,7 +1,7 @@
 ---
 name: Stalker
 menu: The Village
-route: roles/Stalker
+route: /roles/Stalker
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/strongman.mdx
+++ b/src/guides/village/strongman.mdx
@@ -1,7 +1,7 @@
 ---
 name: Strongman
 menu: The Village
-route: roles/Strongman
+route: /roles/Strongman
 ---
 
 # Strongman

--- a/src/guides/village/tarotreader.mdx
+++ b/src/guides/village/tarotreader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tarot Reader
 menu: The Village
-route: roles/TarotReader
+route: /roles/TarotReader
 ---
 
 # Tarot Reader

--- a/src/guides/village/thief.mdx
+++ b/src/guides/village/thief.mdx
@@ -1,7 +1,7 @@
 ---
 name: Thief
 menu: The Village
-route: roles/Thief
+route: /roles/Thief
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/village/village.mdx
+++ b/src/guides/village/village.mdx
@@ -1,7 +1,7 @@
 ---
 name: Village
 menu: The Village
-route: roles/Village
+route: /roles/Village
 ---
 
 # The Village

--- a/src/guides/village/villager.mdx
+++ b/src/guides/village/villager.mdx
@@ -1,7 +1,7 @@
 ---
 name: Villager
 menu: The Village
-route: roles/Villager
+route: /roles/Villager
 ---
 
 # Villager

--- a/src/guides/village/witchhunter.mdx
+++ b/src/guides/village/witchhunter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Witch Hunter
 menu: The Village
-route: roles/WitchHunter
+route: /roles/WitchHunter
 ---
 
 # Witch Hunter

--- a/src/guides/village/zealot.mdx
+++ b/src/guides/village/zealot.mdx
@@ -1,7 +1,7 @@
 ---
 name: Zealot
 menu: The Village
-route: roles/Zealot
+route: /roles/Zealot
 ---
 
 # Zealot

--- a/src/guides/wolfpack/alphawolf.mdx
+++ b/src/guides/wolfpack/alphawolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Alphawolf
 menu: The Wolfpack
-route: roles/Alphawolf
+route: /roles/Alphawolf
 ---
 
 # Alphawolf

--- a/src/guides/wolfpack/bloodhound.mdx
+++ b/src/guides/wolfpack/bloodhound.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodhound
 menu: The Wolfpack
-route: roles/Bloodhound
+route: /roles/Bloodhound
 ---
 
 # Bloodhound

--- a/src/guides/wolfpack/bloodletter.mdx
+++ b/src/guides/wolfpack/bloodletter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodletter
 menu: The Wolfpack
-route: roles/Bloodletter
+route: /roles/Bloodletter
 ---
 
 # Bloodletter

--- a/src/guides/wolfpack/bloodthirster.mdx
+++ b/src/guides/wolfpack/bloodthirster.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bloodthirster
 menu: The Wolfpack
-route: roles/Bloodthirster
+route: /roles/Bloodthirster
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/wolfpack/direwolf.mdx
+++ b/src/guides/wolfpack/direwolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Direwolf
 menu: The Wolfpack
-route: roles/Direwolf
+route: /roles/Direwolf
 ---
 
 # Direwolf

--- a/src/guides/wolfpack/omegawolf.mdx
+++ b/src/guides/wolfpack/omegawolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Omegawolf
 menu: The Wolfpack
-route: roles/Omegawolf
+route: /roles/Omegawolf
 ---
 
 import { Timeline, Event } from 'react-trivial-timeline';

--- a/src/guides/wolfpack/shapeshifter.mdx
+++ b/src/guides/wolfpack/shapeshifter.mdx
@@ -1,7 +1,7 @@
 ---
 name: Shapeshifter
 menu: The Wolfpack
-route: roles/Shapeshifter
+route: /roles/Shapeshifter
 ---
 
 # Shapeshifter

--- a/src/guides/wolfpack/werewolf.mdx
+++ b/src/guides/wolfpack/werewolf.mdx
@@ -1,7 +1,7 @@
 ---
 name: Werewolf
 menu: The Wolfpack
-route: roles/Werewolf
+route: /roles/Werewolf
 ---
 
 # Werewolf

--- a/src/guides/wolfpack/wolfpack.mdx
+++ b/src/guides/wolfpack/wolfpack.mdx
@@ -1,7 +1,7 @@
 ---
 name: Wolfpack
 menu: The Wolfpack
-route: roles/Wolfpack
+route: /roles/Wolfpack
 ---
 
 # The Wolfpack


### PR DESCRIPTION
Something seems to have changed at some point, and without the leading `/` some of the generated paths in link URLs are not being generated correctly leading to the site attempting to link to incorrectly, such as if you are on the items page you might get a link `/guides/items/online-werewolf-rules` for the rules page.

A side effect of this, was that BloodmoonCult ended up being the site index again, despite `1_general/1_basics.mdx` (Removing the `/`s seems to make basics the root. Renaming these from `1_` to `aaa_` seems to have the intended result of making this the first page, so I suspect some weird sorting going on somewhere.

Also fixed the header linking to `/guides/guides/` not `/guides/`
