### PR TITLE
Elaborate Neutral landing page and Tanner's role as solo-evil

### DIFF
--- a/src/guides/neutral/neutral.mdx
+++ b/src/guides/neutral/neutral.mdx
@@ -6,6 +6,15 @@ route: /roles/Neutral
 
 # Neutral Roles
 
-The Neutral Roles are held by players who, either permanently or temporarily, are not aligned with any other faction of players having the same win condition.
+The Neutral Roles are held by players who, either permanently or temporarily, are not aligned with any other faction of players having the same win condition,
+but instead act independently. 
 
-## Tips
+Neutral roles fall into two major categories. The first category, which includes roles like the Drunk and Graverobber, have players work as free agents
+with other factions, usually ending up with a faction-aligned role and playing amicably to the factions they want to join until then. The second category, which
+includes roles like the Tanner and Skinchanger, consists of solo evil players who are attempting to defeat all other factions in the village via their own
+win conditions.
+
+Neutral players, unless otherwise stated on their role pages, are not counted as evils for the sake of parity checks. If the remaining village population
+consists only of villagers and such neutral players, the game will end in a village victory (which usually means a loss for the neutral player if they have
+not accomplished their win condition). However, some neutrals, usually solo evil players, _are_ counted as evils in parity checks and must be eliminated
+in order for the village to win.

--- a/src/guides/neutral/skinchanger.mdx
+++ b/src/guides/neutral/skinchanger.mdx
@@ -4,6 +4,7 @@ menu: The Neutral
 route: /roles/Skinchanger
 ---
 
+import { Timeline, Event } from 'react-trivial-timeline';
 
 # Skinchanger
 

--- a/src/guides/neutral/skinchanger.mdx
+++ b/src/guides/neutral/skinchanger.mdx
@@ -1,0 +1,41 @@
+---
+name: Skinchanger
+menu: The Neutral
+route: /roles/Skinchanger
+---
+
+# Tanner
+
+The Skinchanger is a solo-evil neutral player. Its goal is to eliminate the entire village, both villagers and evils, and they have the ability to shapeshift into each victim they claim.
+
+## Role Type
+
+- The Skinchanger is seen as a Malevolent Spirit by the Seer.
+- The Skinchanger is seen as a user of witchcraft.
+- The Skinchanger will be seen visiting by the Harlot/Stalker/Familiar.
+- The Skinchanger is seen as a killer by the Adjudicator.
+- The Skinchanger is night immune - it cannot be killed at night, roleblocked, or redirected.
+
+## Notes
+
+- The Skinchanger is much like a Vampire in that it acts alone, can kill once each night, and are night immune. The Skinchanger, however, has no power to recruit additional members to its faction and does not possess a night chat.
+- Instead, whenever the Skinchanger kills a player, it has the option to shift into its target, in the same way a Shapeshifter would. When it does this, the Skinchanger assumes the identity of its target, who will appear to die in the Skinchanger's old body.
+- There is no limit to the number of times a Skinchanger may shift.
+- The Skinchanger must shift at least once every three days in order to survive. If it fails to shift for 3 nights in a row, it will die the 4th night, similar to the Maple Wolf.
+- The Skinchanger itself is night immune, but its kills can be protected against by a Protector or a similar role. If a Huntsman blocks a Skinchanger's kill, the Huntsman will be killed instead and no shift will occur, even if one was attempted.
+- Skinchangers _are_ counted as evils in parity checks. The village, and other evils in the village, must eliminate you in order to win. 
+- If a game contains multiple Skinchangers, each is aligned independently and must eliminate the others to win. Note that, as night-immune players, Skinchangers cannot deal with each other by killing each other at night.
+
+## Tips
+
+- With your ability to shift at will, you are notoriously hard to catch. Your opponents will essentially be forced to deal with you immediately as soon as they find information that locates you - do whatever you can to delay your execution so that you can shift at nightfall.
+- Once you have been found, Stalkers are your worst enemy - they can see you visit your target even though the morning's death announcements do not indicate them. This is especially pertinent as most factions possess some kind of Stalker role, and those that don't may be given a Fjät Rune to track you down.
+- Skinchangers are often given items to help balance the fact that they are alone. One especially helpful item is the Iron Collar, which protects you from a single lynch. Other, less powerful items are also useful in throwing off a Stalker, as they generate additional visits alongside the killing visit.
+- More so than with any other role, you will want to take care that others do not notice the change in player. Players will take note of things like typing styles, voting and activity patterns, and of course past claims, including any information received on the night of the shift (which you will not be able to see). Since you are night immune, you will also fail to see attempts to roleblock you, and since you will be attacking evil factions, they will also notice as their members disappear from their night chats or fail to give code words when they appear for the day. If you do not feel you can safely shift a player, you should kill them normally instead.
+
+## History
+
+<Timeline lineColor="white">
+  <Event interval="TODO">No longer required to shift into their kill target each night, but must shift at least once every 3 nights to survive</Event>
+  <Event interval="TODO">Introduced in ext-342</Event>
+</Timeline>

--- a/src/guides/neutral/skinchanger.mdx
+++ b/src/guides/neutral/skinchanger.mdx
@@ -4,38 +4,43 @@ menu: The Neutral
 route: /roles/Skinchanger
 ---
 
+import { Timeline, Event } from 'react-trivial-timeline';
+
 # Tanner
 
-The Skinchanger is a solo-evil neutral player. Its goal is to eliminate the entire village, both villagers and evils, and they have the ability to shapeshift into each victim they claim.
+The Skinchanger is a solo-evil neutral player. Its goal is to eliminate the entire village, both villagers and evils, and it has the ability to shapeshift into each victim it claims.
 
 ## Role Type
 
 - The Skinchanger is seen as a Malevolent Spirit by the Seer.
-- The Skinchanger is seen as a user of witchcraft.
+- The Skinchanger is not seen as a user of witchcraft.
 - The Skinchanger will be seen visiting by the Harlot/Stalker/Familiar.
 - The Skinchanger is seen as a killer by the Adjudicator.
 - The Skinchanger is night immune - it cannot be killed at night, roleblocked, or redirected.
 
 ## Notes
 
-- The Skinchanger is much like a Vampire in that it acts alone, can kill once each night, and are night immune. The Skinchanger, however, has no power to recruit additional members to its faction and does not possess a night chat.
-- Instead, whenever the Skinchanger kills a player, it has the option to shift into its target, in the same way a Shapeshifter would. When it does this, the Skinchanger assumes the identity of its target, who will appear to die in the Skinchanger's old body.
+- The Skinchanger is much like a Vampire in that it acts alone, can kill once each night, and is night immune. The Skinchanger, however, has no power to recruit additional members to its faction and does not possess a night chat.
+- Instead, whenever the Skinchanger kills a player, it has the option to shift into them, in the same way a Shapeshifter werewolf would. When it does this, the Skinchanger assumes the identity of its target, who will appear to die in the Skinchanger's old body.
 - There is no limit to the number of times a Skinchanger may shift.
 - The Skinchanger must shift at least once every three days in order to survive. If it fails to shift for 3 nights in a row, it will die the 4th night, similar to the Maple Wolf.
 - The Skinchanger itself is night immune, but its kills can be protected against by a Protector or a similar role. If a Huntsman blocks a Skinchanger's kill, the Huntsman will be killed instead and no shift will occur, even if one was attempted.
-- Skinchangers _are_ counted as evils in parity checks. The village, and other evils in the village, must eliminate you in order to win. 
+- Skinchangers _are_ counted as evils in parity checks. The village, and other evils in the village, must eliminate you in order to win.
 - If a game contains multiple Skinchangers, each is aligned independently and must eliminate the others to win. Note that, as night-immune players, Skinchangers cannot deal with each other by killing each other at night.
 
 ## Tips
 
 - With your ability to shift at will, you are notoriously hard to catch. Your opponents will essentially be forced to deal with you immediately as soon as they find information that locates you - do whatever you can to delay your execution so that you can shift at nightfall.
-- Once you have been found, Stalkers are your worst enemy - they can see you visit your target even though the morning's death announcements do not indicate them. This is especially pertinent as most factions possess some kind of Stalker role, and those that don't may be given a Fjät Rune to track you down.
+- Once you have been found, Stalkers are your worst enemy - they can see you visit your target and will thus be able to follow you into the next day, even if you shift. This is especially pertinent as most factions possess some kind of Stalker role, and those that don't may be given a Fjät Rune to track you down.
 - Skinchangers are often given items to help balance the fact that they are alone. One especially helpful item is the Iron Collar, which protects you from a single lynch. Other, less powerful items are also useful in throwing off a Stalker, as they generate additional visits alongside the killing visit.
 - More so than with any other role, you will want to take care that others do not notice the change in player. Players will take note of things like typing styles, voting and activity patterns, and of course past claims, including any information received on the night of the shift (which you will not be able to see). Since you are night immune, you will also fail to see attempts to roleblock you, and since you will be attacking evil factions, they will also notice as their members disappear from their night chats or fail to give code words when they appear for the day. If you do not feel you can safely shift a player, you should kill them normally instead.
 
 ## History
 
 <Timeline lineColor="white">
-  <Event interval="TODO">No longer required to shift into their kill target each night, but must shift at least once every 3 nights to survive</Event>
-  <Event interval="TODO">Introduced in ext-342</Event>
+  <Event interval="2020-05-10">
+    No longer required to shift into their kill target each night, but must
+    shift at least once every 3 nights to survive
+  </Event>
+  <Event interval="2019-09-14">Introduced in ext-342</Event>
 </Timeline>

--- a/src/guides/neutral/tanner.mdx
+++ b/src/guides/neutral/tanner.mdx
@@ -8,7 +8,7 @@ import { Timeline, Event } from 'react-trivial-timeline';
 
 # Tanner
 
-The Tanner is a solo-evil neutral player. The Tanner hates their job, the village is forcing them to do it, and they want out.
+The Tanner is a solo neutral player. The Tanner hates their job, the village is forcing them to do it, and they want out.
 
 The Tanner's goal is to trick the village into lynching them. If they are lynched, the game immediately ends and the Tanner wins.
 

--- a/src/guides/neutral/tanner.mdx
+++ b/src/guides/neutral/tanner.mdx
@@ -6,7 +6,9 @@ route: /roles/Tanner
 
 # Tanner
 
-The Tanner is a neutral player. They hate their job and they want out. The Tanner wins the game by getting lynched. If they are lynched, the game immediately ends.
+The Tanner is a solo-evil neutral player. The Tanner hates their job and the village is forcing them to do it.
+
+The Tanner's goal is to trick the village into lynching them. If they are lynched, the game immediately ends and the Tanner wins.
 
 ## Role Type
 
@@ -17,13 +19,16 @@ The Tanner is a neutral player. They hate their job and they want out. The Tanne
 
 ## Notes
 
-- The Tanner only wins if they are lynched, being killed at night does not count.
-- The Tanner cannot be recruited by sub-faction leaders (Mason, Inquisition, Illuminati). However, they can be recruited by a Vampire or Vampire Master.
 - The Tanner is only used in Speed Games.
+- The Tanner is one of the default roles granted to speed game hosts, alongside the Seer and the Werewolf.
+- The Tanner only wins if they are lynched. Being killed at night does not count, nor do they win if the other evil factions die before they do.
+- The Tanner cannot be recruited by sub-faction leaders (Mason, Inquisition, Illuminati). However, they can be recruited by a Vampire or Vampire Master.
+- If a game contains multiple Tanners, only the Tanner that manages to get themselves lynched wins - the other Tanners do not win with this Tanner,
+  and the group of Tanners do not share a night chat.
 
 ## Tips
 
-- Tanners are a danger to the wolves as well as the village. Don't rely on the wolves being happy to bandwagon a vote against you if you are too obvious.
+- Tanners are a danger to the evil factions as well as the village. Don't rely on evils being happy to bandwagon a vote against you if you are too obvious.
 
 ## History
 

--- a/src/guides/neutral/tanner.mdx
+++ b/src/guides/neutral/tanner.mdx
@@ -4,9 +4,11 @@ menu: The Neutral
 route: /roles/Tanner
 ---
 
+import { Timeline, Event } from 'react-trivial-timeline';
+
 # Tanner
 
-The Tanner is a solo-evil neutral player. The Tanner hates their job and the village is forcing them to do it.
+The Tanner is a solo-evil neutral player. The Tanner hates their job, the village is forcing them to do it, and they want out.
 
 The Tanner's goal is to trick the village into lynching them. If they are lynched, the game immediately ends and the Tanner wins.
 


### PR DESCRIPTION
# Description

- Add page for the Skinchanger
- Expand the neutral page to distinguish between "free agent" Neutrals and solo evils
- Elaborate the Tanner's role as a solo evil

# Checklist

I have checked the following _(mark as completed with [x])_:

- [x] The content is accurate (and confirmed with the mods)
- [x] Casing and wording of keywords such as role names, factions, etc, is all correct
- [x] The Markdown is valid
- [x] It renders correctly _(follow README for instructions on previewing)_
- [x] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
