### PR TITLE
Add missing information for neutral roles

### DIFF
--- a/src/guides/neutral/displaced.mdx
+++ b/src/guides/neutral/displaced.mdx
@@ -22,6 +22,7 @@ Once a player has become displaced, they must recover their original role before
 ## Notes
 
 - The Displaced is only used in Speed Games.
+- Each night, the Displaced player targets one other player to search for their role. If they successfully identify the Essence Thief, they will recover their original role, and the Essence Thief will revert and be killed.
 - If the original role of the Displaced uses a one-time ability, the ability will be recharged once they steal their role back.
 
 ## Tips

--- a/src/guides/neutral/drunk.mdx
+++ b/src/guides/neutral/drunk.mdx
@@ -10,7 +10,7 @@ import { Timeline, Event } from 'react-trivial-timeline';
 
 The Drunk is a neutral player who does not currently know their actual role.
 
-The Drunk is a seldom used role and most often used to help the Moderator rebalance large setups.
+The Drunk is a seldom used role and most often used to help a Moderator rebalance large setups.
 
 ## Role Type
 
@@ -21,8 +21,10 @@ The Drunk is a seldom used role and most often used to help the Moderator rebala
 
 ## Notes
 
+- Sobering up can happen at any time, including in the middle of the day.
 - Until such time as the Drunk sobers up they count as a member of the Village when evaluating the win-conditions for the other factions.
-- There is no fixed time as to when the Drunk sobers up, but when they do they fully-embrace their new role and faction and win/lose as that faction.
+- There is no fixed time as to when the Drunk sobers up, but when they do they fully embrace their new role and faction and win/lose as that faction.
+- A Drunk player might also be given items when they sober up.
 
 ## Tips
 

--- a/src/guides/neutral/essencethief.mdx
+++ b/src/guides/neutral/essencethief.mdx
@@ -22,8 +22,10 @@ The victim of the Essence Thief becomes 'Displaced' and will be trying to re-cap
 ## Notes
 
 - The Essence Thief is only used in Speed Games.
-- Once the Essence Thief successfully steals a role from a player, they become that role completely, including any night chats.
+- Once the Essence Thief successfully steals a role from a player, they become that role completely, including any night chats and victory conditions.
 - One time abilities will be available to the Essence Thief even if the victim had already used it.
+- If the Displaced manages to successfully target the Essence Thief, the Essence Thief will revert to their original role and be killed, causing them to lose the game.
+- An Essence Thief that fails to steal a role at all during the course of the game will lose.
 
 ## Tips
 

--- a/src/guides/neutral/graverobber.mdx
+++ b/src/guides/neutral/graverobber.mdx
@@ -6,7 +6,7 @@ route: /roles/Graverobber
 
 # Graverobber
 
-The Graverobber can steal up to one role from a dead player. Before they steal a role they are a member of the village, but once they have stolen a role their alignment corresponds with their new role. There are a few exceptions to the roles that the Graverobber can take. If the Graverobber attempts to steal one of these roles, nothing happens and the Graverobber can try again next night. Once the Graverobber has stolen a role, they continue the game as that role and have no option to try and steal another role.
+The Graverobber begins the game as a neutral party. Once per game, they can select a player from the Graveyard and completely assume that player's role.
 
 ## Role Type
 
@@ -17,15 +17,16 @@ The Graverobber can steal up to one role from a dead player. Before they steal a
 
 ## Notes
 
-- The information given in the Role Type section is only true if the Graverobber has not taken on a new identity yet - once they have a new role, all role characteristics correspond to that role.
+- The information given in the Role Type section is only true if the Graverobber has not taken on a new identity yet - once they have a new role, they assume that role completely, including all characteristics, factions, and night actions.
 - There is no way to distinguish between a player who has a role from the start of the game and a player who has stolen the role during the game.
-- If the Graverobber has targeted an appropriate role, they take on the role at dawn. Before dawn, they are still considered to be a Graverobber, and any roles targeting them will be carried out accordingly. For example: the Seer checks the Graverobber the night they steal the role of a member of the Wolfpack. The Seer still gets the report that they have found a member of the village.
+- If the Graverobber has targeted an appropriate role, they take on the role at dawn. Before dawn, they are still considered to be a Graverobber, and any roles targeting them will be carried out accordingly. For example, if the Seer checks the Graverobber the night they steal the role of a member of the Wolfpack, the Seer still gets the report that they have found a Neutral Party.
 - If the Graverobber successfully steals a role, they will be able to use it from the next night onwards, but not the same night as they stole the role.
-- The following roles can not be robbed: the Villager, the Lycan, the Insomniac, the Sleepwalker; the Puppet Master, the Djinn, the Succubus; the Vampire, the Familiar. Additionally, you cannot steal the role of somebody who has been shapeshifted into (a person whose Gravedigger report comes up as 'Undetermined').
+- The following roles can not be robbed: the Villager, the Lycan, the Insomniac, the Sleepwalker; the Puppet Master, the Djinn, the Succubus; the Vampire, the Familiar. Additionally, you cannot steal the role of somebody who has been shapeshifted into (a person whose Gravedigger report comes up as 'Undetermined'). If the Graverobber attempts to steal one of these roles, nothing happens and the Graverobber can try again the next night.
+- If the Graverobber goes through the whole game without ever successfully taking a role, they lose the game.
 
 ## Tips
 
-- The Graverobber is very versatile, because you can become many different roles and may even change the faction to which you belong. This means that there are many ways in which to play this role - there is not one single defined way to play it. Nevertheless, some general guidelines can be given.
+- The Graverobber is very versatile, because you can become many different roles and even assume any faction present in the game. This means that there are many ways in which to play this role - there is not one single defined way to play it. Nevertheless, some general guidelines can be given.
 - If you wish to help the village, it is generally safe to try to steal the roles of people that die in the night. This only holds if there is no Vampire or Coven present. You should also only steal the roles of people that were the only one to die (if there are 2 deaths, one may be a wolf and the other a Huntsman, for example). This way, it is highly unlikely that you will not steal a village-aligned role.
 - It is possible to start robbing people from N2 onwards, to try to assume a role as soon as possible. You can also wait until some more information comes up about the people that are dead, e.g. until a Gravedigger shares their information about the Graveyard.
 - You can state publicly which role you have, although the village may be suspicious of you - they cannot be sure that you will not change your alignment during the game! Evil factions may also want you dead if they expect that you will steal a village-aligned role. In that sense, the Graverobber is in a tricky position because they have no certain allies...


### PR DESCRIPTION
# Description

- Displaced uses night action to find the Essence Thief
- Essence Thief loses if they're found or never claim a role
- Drunk can sober up at any time, including during the day
- Graverobber is consistently neutral in text

# Checklist

I have checked the following _(mark as completed with [x])_:

- [ ] The content is accurate (and confirmed with the mods)
- [x] Casing and wording of keywords such as role names, factions, etc, is all correct
- [x] The Markdown is valid
- [ ] It renders correctly _(follow README for instructions on previewing)_
- [ ] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
