### PR TITLE
Revamp the H2P's explanation of night actions

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -13,6 +13,7 @@ export default {
         'Rules',
         'Victory Conditions',
         'Buttons & Abilities',
+        'Night Action Order',
         'Tips',
         'Community Guidelines'
       ]

--- a/src/guides/aaa_general/aaa_basics.mdx
+++ b/src/guides/aaa_general/aaa_basics.mdx
@@ -6,37 +6,39 @@ route: /how-to-play-online-werewolf
 
 # How to Play Werewolf Online
 
-werewolv.es has two basic game modes. 24 hour games and speed rounds. The 24 hour games have 12-hour day and night cycles. In speed rounds a day and night only take a few minutes. The 24 hour games are played continuously - there is usually one ongoing, and one where you can sign up, at any moment. The speed games are occasionally hosted in the weekend. Whichever mode is used, victory conditions and basic play remains the same: The village is trying to work out who are killing them during the night, and the evil factions are trying to stay hidden until they have whittled down the numbers of the village. The evil factions are: the Werewolves, the Coven, and the Vampire - each game includes at least one, and possibly multiple, of these factions. The game is divided into two basic phases, day and night.
+werewolv.es has two basic game modes. 24 hour games and speed rounds. The 24 hour games have 12-hour day and night cycles. In speed rounds a day and night only take a few minutes. The 24 hour games are played continuously - there is usually one ongoing, and one where you can sign up, at any moment. The speed games are occasionally hosted in the weekend. Whichever mode is used, victory conditions and basic play remains the same: The village is trying to work out who are killing them during the night, and the evil factions are trying to stay hidden until they have whittled down the numbers of the village. The evil factions are: the Werewolves, the Coven, the Vampire, and the Undead - each game includes at least one, and possibly multiple, of these factions, and may also include factions that assist these evils, or independent neutral or evil players outside of any faction.
 
-## Night Phase
-
-During the night phase, members of evil factions can talk to their allies in secret and choose their victim(s). This is the time that special characters can decide how to use their unique ability. When night is over, abilities and kills are resolved and day begins.
+The game is divided into two basic phases, day and night.
 
 ## Day Phase
 
 The daytime is where most of the game of werewolv.es actually takes place. The village must talk amongst itself and piece together whatever scraps of information they may have been able to find in order to work out who the enemies are. Once the village has a suspicion, they are able to democratically lynch someone. Once they have lynched all evils, they win.
 
-## Lynching
+Note that the first day phase only lasts a short time, and does not include a lynch vote - instead, this gives players time to settle into the game, converse briefly with the other players, and review their role and any setup information. However, since this day phase is present, it means that if you an evil player, you will not have access to your private night chat until the first night is officially announced.
 
-Votes are cast throughout the day and when night falls, the player with the most votes is lynched by the village. If there is a tie, nobody is lynched.
+### Identities
 
-## Order of Night Actions
+Rather than having players play under their own usernames and avatars, games usually assign each player a random name and avatar from a theme. This allows games to be anonymous and disconnect players from tells that could otherwise put them in a disadvantage. In games where this is used, it is against the rules to divulge your true identity outside of any faction night chat you may have - the information of which identity mapped to which player will be revealed when the game ends.
 
-The different abilities roles have at night may influence each other. How they do is determined by the order in which the night actions are defined to take place. The order of night actions is:
+### Lynching
 
-1. Redirects (Succubus)
-2. Roleblocks (Direwolf)
-3. Protection visits (Protector, Huntsman, Shaman)
-4. Most visits (Too many to list: all visits not belonging in another category)
-5. Active Item visits (Crossbows, potions etc)
-6. Item Transfers
-7. Resolve kills (Killing werewolf (Werewolf/Alphawolf/Shapeshifter), Vampire, Witch, Militia)
-8. Report visits to Stalkers, Harlots, Familiar
-9. Resolve item thefts (from abilities, potions and kills)
-10. Swap Identities (Djinn, Shapeshifter)
-11. Report kills to village
-12. Report revives to village
+Votes are cast throughout the day and when night falls, the player with the most votes is lynched by the village, eliminating them from the game. If there is a tie, nobody is lynched. Most games also offer the option for the village to deliberately choose not to lynch anyone.
 
-Some general points: nightly abilities will still take place even if the role is killed that night, as the majority of abilities and actions happen simultaneously. This also holds for all identity-swapping abilities (Djinn, Shapeshifter) just as for other abilities. The important point to note here is that, by the time the identities of players are swapped, the game has already determined who is going to be killed that night. Thus identity-swapping abilities can never change which _player_ will die in the night, but they can change which _character_ will be reported dead at dawn. For example: if a Shapeshifter is targeted by some killing ability, they cannot escape their fate by shifting into some other character that night.
+In order to promote player activity, players must cast a vote at least once every two days, and preferably vote each day. A player that fails to vote for two days in a row is smited, eliminating them from the game. Players can also be smited by the moderator at any time for breaking game rules.
 
-Note that all roles get reports on the situation before identity-swapping abilities, meaning that your information is possibly outdated by the time you receive it.
+## Night Phase
+
+During the night phase, members of evil factions can talk to their allies in secret and choose their victim(s). This is the time that special characters can decide how to use their unique ability. When night is over, abilities and kills are resolved and day begins.
+
+### Types of night actions
+
+Night actions fall into a wide array of categories. They are too exhaustive to list, but these are some of the main ones players will encounter:
+
+- Actions that kill players (such as that of the Werewolf). A target of such an action, if successfully executed, will be eliminated from the game and placed in the Graveyard chat, and their death will be publicly reported in the morning. Note that kills do not stop players from performing their night actions - unless the action fails another way, a player can perform their own night action, even killing another player, on a night when they themselves are killed. There are various actions and role characteristics that prevent or redirect kills, and special kill actions that can bypass some or all of these mitigations.
+- Actions that gather intelligence (such as that of the Seer). A user of this action will receive a report in the morning revealing some information about their target, such as their role alignment, the players they visited (used their actions on) that night, or other auxilliary information. Each role page in this How to Play guide contains data about the kind of information that these intelligence roles can see.
+- Actions that protect against kills (such as that of the Protector). A target of this action is protected from attempted kills against them during the night on which it is used. In most cases, the kill action simply fails, though some protective actions cause other effects to happen if someone attempts to kill the protected player - for instance, the Huntsman will kill all players that attempt to attack their target, but will also die in the process. Some kill actions are able to bypass protection, such as that of the Militia.
+- Actions that revive players (such as that of the Reviver). A rare action, this allows a previously killed or lynched player to return to the game. In addition to regaining their night actions (unless already used up), night chats, and voting abilities, they may also carry information with them that they learned from the Graveyard chat.
+- Actions that block roles (such as that of the Direwolf). If a player is targeted by a successful roleblocking action, their own night action will not take place. These actions are resolved close to first in the order of night actions in order to block as many actions as possible. Some characters, such as the Vampire and roleblockers themselves, are immune to role blocks.
+- Actions that swap identities (such as that of the Shapeshifter). Targets of these actions swap their avatar and username assignments - this swap is not made known to anyone besides the targets, and each will appear as their new identities to the rest of the village. These swaps, however, do not exchange any other characteristics of the players, including their factions, night chats, abilities, and statuses. These actions are always performed last, just before kills and revives are reported to the village, which means that a swap cannot change the target of your night action, but that any intelligence reports you get might instead apply to a different identity after you get them.
+
+Night actions are committed simultaneously at the end of the night and are resolved in a mostly deterministic way by the game engine. This order is detailed on the Night Action Order page.

--- a/src/guides/aaa_general/aaa_basics.mdx
+++ b/src/guides/aaa_general/aaa_basics.mdx
@@ -34,11 +34,27 @@ During the night phase, members of evil factions can talk to their allies in sec
 
 Night actions fall into a wide array of categories. They are too exhaustive to list, but these are some of the main ones players will encounter:
 
-- Actions that kill players (such as that of the Werewolf). A target of such an action, if successfully executed, will be eliminated from the game and placed in the Graveyard chat, and their death will be publicly reported in the morning. Note that kills do not stop players from performing their night actions - unless the action fails another way, a player can perform their own night action, even killing another player, on a night when they themselves are killed. There are various actions and role characteristics that prevent or redirect kills, and special kill actions that can bypass some or all of these mitigations.
-- Actions that gather intelligence (such as that of the Seer). A user of this action will receive a report in the morning revealing some information about their target, such as their role alignment, the players they visited (used their actions on) that night, or other auxilliary information. Each role page in this How to Play guide contains data about the kind of information that these intelligence roles can see.
-- Actions that protect against kills (such as that of the Protector). A target of this action is protected from attempted kills against them during the night on which it is used. In most cases, the kill action simply fails, though some protective actions cause other effects to happen if someone attempts to kill the protected player - for instance, the Huntsman will kill all players that attempt to attack their target, but will also die in the process. Some kill actions are able to bypass protection, such as that of the Militia.
-- Actions that revive players (such as that of the Reviver). A rare action, this allows a previously killed or lynched player to return to the game. In addition to regaining their night actions (unless already used up), night chats, and voting abilities, they may also carry information with them that they learned from the Graveyard chat.
-- Actions that block roles (such as that of the Direwolf). If a player is targeted by a successful roleblocking action, their own night action will not take place. These actions are resolved close to first in the order of night actions in order to block as many actions as possible. Some characters, such as the Vampire and roleblockers themselves, are immune to role blocks.
-- Actions that swap identities (such as that of the Shapeshifter). Targets of these actions swap their avatar and username assignments - this swap is not made known to anyone besides the targets, and each will appear as their new identities to the rest of the village. These swaps, however, do not exchange any other characteristics of the players, including their factions, night chats, abilities, and statuses. These actions are always performed last, just before kills and revives are reported to the village, which means that a swap cannot change the target of your night action, but that any intelligence reports you get might instead apply to a different identity after you get them.
+- Actions that **kill players** (such as that of the Werewolf):
+  - A target of such an action, if successfully executed, will be eliminated from the game and placed in the Graveyard chat, and their death will be publicly reported in the morning.
+  - Note that kills do not stop players from performing their night actions - unless the action fails another way, a player can perform their own night action, even killing another player, on a night when they themselves are killed.
+  - There are various actions and role characteristics that prevent or redirect kills, and special kill actions that can bypass some or all of these mitigations.
+- Actions that **gather intelligence** (such as that of the Seer):
+  - A user of this action will receive a report in the morning revealing some information about their target, such as their role alignment, the players they visited (used their actions on) that night, or other auxilliary information.
+  - Each role page in this How to Play guide contains data about the kind of information that these intelligence roles can see.
+- Actions that **protect against kills** (such as that of the Protector):
+  - A target of this action is protected from attempted kills against them during the night on which it is used.
+  - In most cases, the kill action simply fails, though some protective actions cause other effects to happen if someone attempts to kill the protected player - for instance, the Huntsman will kill all players that attempt to attack their target, but will also die in the process.
+  - Some kill actions are able to bypass protection, such as that of the Militia.
+- Actions that **revive players** (such as that of the Reviver):
+  - A rare action, this allows a previously killed or lynched player to return to the game.
+  - In addition to regaining their night actions (unless already used up), night chats, and voting abilities, they may also carry information with them that they learned from the Graveyard chat.
+- Actions that **block roles** (such as that of the Direwolf).
+  - If a player is targeted by a successful roleblocking action, their own night action will not take place.
+  - These actions are resolved close to first in the order of night actions in order to block as many actions as possible.
+  - Some characters, such as the Vampire and roleblockers themselves, are immune to role blocks.
+- Actions that **swap identities** (such as that of the Shapeshifter).
+  - Targets of these actions swap their avatar and username assignments - this swap is not made known to anyone besides the targets, and each will appear as their new identities to the rest of the village.
+  - These swaps, however, do not exchange any other characteristics of the players, including their factions, night chats, abilities, and statuses - in essence, these are the exact same players in new skins.
+  - These actions are always performed last, just before kills and revives are reported to the village, which means that a swap cannot change the target of your night action, but that any intelligence reports you get might instead apply to a different identity after you get them.
 
-Night actions are committed simultaneously at the end of the night and are resolved in a mostly deterministic way by the game engine. This order is detailed on the Night Action Order page.
+Night actions are committed simultaneously at the end of the night and are resolved in a mostly deterministic way by the game engine. This order is detailed on the [Night Action Order](/night-action-order) page.

--- a/src/guides/aaa_general/night-action-order.mdx
+++ b/src/guides/aaa_general/night-action-order.mdx
@@ -1,0 +1,34 @@
+---
+name: Basics
+menu: Night Action Order
+route: /night-action-order
+---
+
+# Order of Night Actions
+
+The different abilities roles have at night may influence each other. How they do is determined by the order in which the night actions are defined to take place. The order of night actions is:
+
+1. Redirects (Succubus)
+1. Roleblocks (Direwolf, Courtesan, Manacles of Spite)
+1. Protection visits (Protector, Huntsman, Shaman, Armour, Heavy Shield)
+1. Most visits (Too many to list: all visits not belonging in another category, including items)
+1. Item thefts from abilities and potions
+1. Kills (Killing werewolf (Werewolf/Alphawolf/Shapeshifter), Vampire, Witch, Militia), including resulting item thefts
+1. Report visits to Stalkers, Harlots, Familiar
+1. Passing of items
+1. Swap Identities (Djinn, Shapeshifter)
+1. Report kills to village
+1. Report revives to village
+
+Multiple actions that fall in the same category are executed more or less simultaneously. Conflicts between such actions are resolved in the following manner:
+
+- Redirects and identity swaps occur in a determinsitic, server-defined order, which may cause them to be unpredictable if two or more such actions
+  target the same player.
+- If a player is roleblocked multiple times, they will receive one message for each roleblock, but receive no additional effect.
+- Protection visits stack - the player is protected by all sources protecting them, and if a player is attacked, all associated effects trigger.
+- If multiple players attempt to steal from the same target with the same priority of action, no items are stolen.
+- If multiple players successfully kill the same target, all effects attached to all kills trigger.
+
+Some general points: nightly abilities will still take place even if the role is killed that night, as the majority of abilities and actions happen simultaneously. This also holds for all identity-swapping abilities (Djinn, Shapeshifter) just as for other abilities. The important point to note here is that, by the time the identities of players are swapped, the game has already determined who is going to be killed that night. Thus identity-swapping abilities can never change which _player_ will die in the night, but they can change which _character_ will be reported dead at dawn. For example: if a Shapeshifter is targeted by some killing ability, they cannot escape their fate by shifting into some other character that night.
+
+Note that all roles get reports on the situation before identity-swapping abilities, meaning that your information is possibly outdated by the time you receive it.

--- a/src/guides/aaa_general/night-action-order.mdx
+++ b/src/guides/aaa_general/night-action-order.mdx
@@ -1,6 +1,6 @@
 ---
-name: Basics
-menu: Night Action Order
+name: Night Action Order
+menu: General
 route: /night-action-order
 ---
 

--- a/src/guides/aaa_general/night-action-order.mdx
+++ b/src/guides/aaa_general/night-action-order.mdx
@@ -1,6 +1,6 @@
 ---
-name: Basics
-menu: Night Action Order
+name: Night Action Order
+menu: General
 route: /night-action-order
 ---
 
@@ -22,12 +22,11 @@ The different abilities roles have at night may influence each other. How they d
 
 Multiple actions that fall in the same category are executed more or less simultaneously. Conflicts between such actions are resolved in the following manner:
 
-- Redirects and identity swaps occur in a determinsitic, server-defined order, which may cause them to be unpredictable if two or more such actions
-  target the same player.
+- Redirects and identity swaps occur in a determinsitic, server-defined order, which may cause them to act unpredictably if two or more such actions target the same player.
 - If a player is roleblocked multiple times, they will receive one message for each roleblock, but receive no additional effect.
-- Protection visits stack - the player is protected by all sources protecting them, and if a player is attacked, all associated effects trigger.
-- If multiple players attempt to steal from the same target with the same priority of action, no items are stolen.
-- If multiple players successfully kill the same target, all effects attached to all kills trigger.
+- Protection visits overlap - the target receives no personal benefit from being protected multiple times, but if the target is attacked, all associated effects trigger.
+- If multiple players attempt to steal from the same target with an ability or potion, no items are stolen.
+- If multiple players successfully kill the same target, the single cause of that kill (and thus who gets any stolen items) will be attributed to a single killer in a deterministic, server-defined order, but all on-success actions for that kill will still trigger.
 
 Some general points: nightly abilities will still take place even if the role is killed that night, as the majority of abilities and actions happen simultaneously. This also holds for all identity-swapping abilities (Djinn, Shapeshifter) just as for other abilities. The important point to note here is that, by the time the identities of players are swapped, the game has already determined who is going to be killed that night. Thus identity-swapping abilities can never change which _player_ will die in the night, but they can change which _character_ will be reported dead at dawn. For example: if a Shapeshifter is targeted by some killing ability, they cannot escape their fate by shifting into some other character that night.
 


### PR DESCRIPTION
# Description

- Swap the orders of Day Phase and Night Phase to more accurately reflect the order they come in
- Explain the anonymous identity mechanic
- Briefly mention smiting
- Move the Night Action Order to a separate page
- Replace the Night Action Order on the main page with expository explanations of the most common actions, including kills, intel, protection, revives, roleblocks, and identity swaps.
- Correct the order of night actions to reflect recent changes
- Discuss how night action conflicts are handled

# Checklist

I have checked the following _(mark as completed with [x])_:

- [x] The content is accurate (and confirmed with the mods)
- [x] Casing and wording of keywords such as role names, factions, etc, is all correct
- [x] The Markdown is valid
- [x] It renders correctly _(follow README for instructions on previewing)_
- [x] The sidebar links are correct and in the right sections _(follow README for instructions on previewing)_
